### PR TITLE
feat: neo-brutalist redesign of VOCA AI website

### DIFF
--- a/script.js
+++ b/script.js
@@ -411,22 +411,22 @@
     function getPalette(tone) {
       if (tone === "coral") {
         return [
-          ["rgba(255, 191, 84, 0.9)", 13, 0.012, 0.2],
-          ["rgba(255, 140, 97, 0.75)", 18, 0.015, 1.0],
-          ["rgba(46, 206, 255, 0.56)", 10, 0.018, 1.7]
+          ["rgba(255, 229, 0, 0.92)", 13, 0.012, 0.2],
+          ["rgba(255, 69, 0, 0.8)", 18, 0.015, 1.0],
+          ["rgba(255, 255, 255, 0.4)", 10, 0.018, 1.7]
         ];
       }
       if (tone === "teal") {
         return [
-          ["rgba(25, 239, 208, 0.88)", 14, 0.011, 0.1],
-          ["rgba(43, 200, 255, 0.78)", 18, 0.014, 0.7],
-          ["rgba(255, 191, 84, 0.5)", 9, 0.019, 1.6]
+          ["rgba(255, 229, 0, 0.9)", 14, 0.011, 0.1],
+          ["rgba(255, 255, 255, 0.65)", 18, 0.014, 0.7],
+          ["rgba(255, 69, 0, 0.5)", 9, 0.019, 1.6]
         ];
       }
       return [
-        ["rgba(25, 239, 208, 0.85)", 18, 0.011, 0.0],
-        ["rgba(43, 200, 255, 0.8)", 30, 0.014, 0.8],
-        ["rgba(255, 140, 97, 0.68)", 12, 0.018, 1.2]
+        ["rgba(255, 229, 0, 0.88)", 18, 0.011, 0.0],
+        ["rgba(255, 255, 255, 0.72)", 30, 0.014, 0.8],
+        ["rgba(255, 69, 0, 0.6)", 12, 0.018, 1.2]
       ];
     }
 
@@ -437,7 +437,7 @@
       const fillAlpha = minimalTheme ? (tone === "hero" ? 0.22 : 0.36) : tone === "hero" ? 0.45 : 0.75;
 
       context.clearRect(0, 0, width, height);
-      context.fillStyle = `rgba(6, 11, 20, ${fillAlpha})`;
+      context.fillStyle = `rgba(13, 13, 13, ${fillAlpha})`;
       context.fillRect(0, 0, width, height);
 
       const palette = getPalette(tone);
@@ -561,7 +561,7 @@
       const height = visualizer.height;
       canvasCtx.clearRect(0, 0, width, height);
 
-      canvasCtx.fillStyle = "rgba(4, 9, 18, 0.9)";
+      canvasCtx.fillStyle = "rgba(13, 13, 13, 0.95)";
       canvasCtx.fillRect(0, 0, width, height);
 
       const barWidth = width / dataArray.length;
@@ -570,14 +570,14 @@
         const barHeight = (value / 255) * (height - 20);
         const x = i * barWidth;
         const y = height - barHeight;
-        const hue = 165 + (i / dataArray.length) * 35;
-        canvasCtx.fillStyle = `hsla(${hue}, 95%, 64%, 0.88)`;
+        const hue = 42 + (i / dataArray.length) * 18;
+        canvasCtx.fillStyle = `hsla(${hue}, 100%, 55%, 0.92)`;
         canvasCtx.fillRect(x, y, Math.max(1, barWidth - 2), barHeight);
       }
 
       canvasCtx.beginPath();
       canvasCtx.lineWidth = 2.2;
-      canvasCtx.strokeStyle = "rgba(156, 238, 255, 0.92)";
+      canvasCtx.strokeStyle = "rgba(255, 229, 0, 0.95)";
       for (let i = 0; i < timeDataArray.length; i += 1) {
         const x = (i / (timeDataArray.length - 1)) * width;
         const y = (timeDataArray[i] / 255) * height;
@@ -601,9 +601,9 @@
       const width = visualizer.width;
       const height = visualizer.height;
       canvasCtx.clearRect(0, 0, width, height);
-      canvasCtx.fillStyle = "rgba(4, 9, 18, 0.9)";
+      canvasCtx.fillStyle = "rgba(13, 13, 13, 0.95)";
       canvasCtx.fillRect(0, 0, width, height);
-      canvasCtx.strokeStyle = "rgba(101, 220, 255, 0.4)";
+      canvasCtx.strokeStyle = "rgba(255, 229, 0, 0.45)";
       canvasCtx.lineWidth = 2;
       canvasCtx.beginPath();
       for (let x = 0; x <= width; x += 8) {
@@ -1107,9 +1107,9 @@
     if (legacyAfter) {
       window.gsap.fromTo(
         legacyAfter,
-        { clipPath: "inset(0 100% 0 0 round 24px)" },
+        { clipPath: "inset(0 100% 0 0 round 0px)" },
         {
-          clipPath: "inset(0 0% 0 0 round 24px)",
+          clipPath: "inset(0 0% 0 0 round 0px)",
           ease: "none",
           scrollTrigger: {
             trigger: "#legacy-shell",

--- a/styles.css
+++ b/styles.css
@@ -1,23 +1,27 @@
+/* ══════════════════════════════════════════════════════════════
+   VOCA AI — NEO-BRUTALIST THEME
+   ══════════════════════════════════════════════════════════════ */
+
 :root {
-  --bg-main: #090f14;
-  --bg-elev: #121b25;
-  --bg-card: rgba(15, 22, 30, 0.78);
-  --text-main: #e6f4ff;
-  --text-muted: #9cb0c5;
-  --line-soft: rgba(136, 212, 255, 0.2);
-  --teal: #52f3cb;
-  --cyan: #56c8ff;
-  --coral: #ff9c72;
-  --amber: #ffce7e;
-  --lime: #9dff78;
-  --radius-lg: 14px;
-  --radius-md: 10px;
-  --shadow-glow: 0 20px 54px rgba(2, 8, 16, 0.55);
-  --font-code: "JetBrains Mono", "IBM Plex Mono", "SFMono-Regular", Menlo, monospace;
-  --font-hand: "Caveat", cursive;
+  --bg-main: #fffef0;
+  --bg-card: #ffffff;
+  --bg-dark: #0d0d0d;
+  --text-main: #0d0d0d;
+  --text-muted: #4a4a4a;
+  --text-inv: #fffef0;
+  --border: #0d0d0d;
+  --bw: 3px;
+  --shadow: 5px 5px 0 #0d0d0d;
+  --shadow-lg: 8px 8px 0 #0d0d0d;
+  --yellow: #ffe500;
+  --orange: #ff4500;
+  --blue: #0055ff;
+  --green: #00e676;
+  --pink: #ff2d78;
   --container: min(1140px, 92vw);
 }
 
+/* ── RESET ─────────────────────────────────────────────────── */
 *,
 *::before,
 *::after {
@@ -31,21 +35,31 @@ html {
 body {
   margin: 0;
   min-height: 100vh;
-  background-image: radial-gradient(circle at 14% 16%, #0f334d 0%, rgba(15, 51, 77, 0) 37%),
-    radial-gradient(circle at 88% 10%, #3a2038 0%, rgba(58, 32, 56, 0) 35%),
-    radial-gradient(circle at 50% 120%, #0e2520 0%, rgba(14, 37, 32, 0) 40%),
-    repeating-linear-gradient(0deg, rgba(133, 191, 234, 0.08) 0, rgba(133, 191, 234, 0.08) 1px, transparent 1px, transparent 26px),
-    repeating-linear-gradient(90deg, rgba(133, 191, 234, 0.06) 0, rgba(133, 191, 234, 0.06) 1px, transparent 1px, transparent 26px),
-    linear-gradient(180deg, #05090f 0%, #0a111a 52%, #080d14 100%);
+  background-color: var(--bg-main);
+  background-image:
+    repeating-linear-gradient(
+      0deg,
+      rgba(0, 0, 0, 0.05) 0,
+      rgba(0, 0, 0, 0.05) 1px,
+      transparent 1px,
+      transparent 28px
+    ),
+    repeating-linear-gradient(
+      90deg,
+      rgba(0, 0, 0, 0.05) 0,
+      rgba(0, 0, 0, 0.05) 1px,
+      transparent 1px,
+      transparent 28px
+    );
   color: var(--text-main);
-  font-family: var(--font-code);
+  font-family: "Poppins", system-ui, sans-serif;
   line-height: 1.5;
   overflow-x: hidden;
-  background-attachment: fixed;
 }
 
 a {
   color: inherit;
+  text-decoration: none;
 }
 
 .container {
@@ -53,2134 +67,1630 @@ a {
   margin: 0 auto;
 }
 
+/* Hide ambient blobs */
 .ambient {
-  position: fixed;
-  inset: auto;
-  width: 36vw;
-  height: 36vw;
-  border-radius: 999px;
-  filter: blur(65px);
-  pointer-events: none;
-  z-index: -1;
-  opacity: 0.38;
+  display: none;
 }
 
-.ambient-a {
-  left: -8vw;
-  top: 16vh;
-  background: linear-gradient(145deg, rgba(24, 238, 206, 0.5), rgba(43, 200, 255, 0.2));
-}
-
-.ambient-b {
-  right: -12vw;
-  top: 54vh;
-  background: linear-gradient(145deg, rgba(255, 140, 97, 0.3), rgba(36, 59, 86, 0.36));
-}
-
-.ambient-c {
-  left: 24vw;
-  bottom: -20vw;
-  background: linear-gradient(145deg, rgba(112, 255, 221, 0.2), rgba(255, 191, 84, 0.16));
-}
-
+/* ── HEADER ─────────────────────────────────────────────────── */
 .site-header {
   position: sticky;
   top: 0;
-  z-index: 30;
-  padding: 0.62rem 0 0.5rem;
-  background: linear-gradient(180deg, rgba(7, 12, 19, 0.92), rgba(7, 12, 19, 0.42));
-  border-bottom: 1px solid rgba(137, 178, 255, 0.14);
-}
-
-.site-header::after {
-  content: "";
-  position: absolute;
-  inset: auto 0 -1px;
-  height: 1px;
-  background: linear-gradient(90deg, rgba(66, 198, 255, 0), rgba(66, 198, 255, 0.55), rgba(66, 198, 255, 0));
-  opacity: 0.7;
-}
-
-.header-inner {
-  min-height: 74px;
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 1.25rem;
-  padding: 0.45rem 0.65rem;
-  border-radius: 12px;
-  border: 1px solid rgba(137, 206, 255, 0.24);
-  background: linear-gradient(165deg, rgba(11, 19, 30, 0.9), rgba(9, 16, 25, 0.97));
-  box-shadow: 0 14px 28px rgba(2, 10, 24, 0.33);
-  backdrop-filter: blur(18px);
-  position: relative;
-  overflow: hidden;
-}
-
-.header-inner::before {
-  content: "";
-  position: absolute;
-  inset: 0;
-  pointer-events: none;
-  background: linear-gradient(
-    105deg,
-    rgba(24, 240, 207, 0.14) 0%,
-    rgba(24, 240, 207, 0) 36%,
-    rgba(43, 200, 255, 0.1) 62%,
-    rgba(255, 154, 106, 0.12) 100%
-  );
+  z-index: 100;
+  background: var(--yellow);
+  border-bottom: var(--bw) solid var(--border);
+  transition: box-shadow 0.15s;
 }
 
 .site-header.scrolled {
-  padding-top: 0.45rem;
+  box-shadow: 0 4px 0 var(--border);
 }
 
-.site-header.scrolled .header-inner {
-  border-color: rgba(157, 220, 255, 0.33);
-  box-shadow: 0 20px 34px rgba(1, 10, 24, 0.48);
+.header-inner {
+  display: flex;
+  align-items: center;
+  height: 60px;
+  gap: 1rem;
 }
 
 .brand {
-  display: inline-flex;
+  display: flex;
   align-items: center;
-  gap: 0.72rem;
+  gap: 0.6rem;
   text-decoration: none;
-  position: relative;
-  z-index: 1;
+  flex-shrink: 0;
 }
 
 .brand-logo {
-  width: 44px;
-  height: 44px;
-  border-radius: 8px;
-  box-shadow: 0 0 0 1px rgba(164, 232, 255, 0.35), 0 0 18px rgba(43, 200, 255, 0.28);
-  animation: logoFloat 3.8s ease-in-out infinite;
+  width: 28px;
+  height: 28px;
 }
 
 .brand-lockup {
-  display: inline-flex;
+  display: flex;
   flex-direction: column;
-  gap: 0.02rem;
+  line-height: 1.1;
 }
 
 .brand-text {
-  font-family: var(--font-code);
-  font-weight: 700;
-  letter-spacing: 0.08em;
-  font-size: 1.06rem;
-  line-height: 1;
-  color: #e8f5ff;
+  font-size: 0.95rem;
+  font-weight: 900;
+  letter-spacing: -0.01em;
+  color: var(--text-main);
+  text-transform: uppercase;
 }
 
 .brand-sub {
-  font-size: 0.78rem;
-  letter-spacing: 0.01em;
+  font-size: 0.55rem;
+  font-weight: 700;
   text-transform: uppercase;
-  color: #79efc6;
-  font-family: var(--font-hand);
+  letter-spacing: 0.1em;
+  color: var(--text-muted);
 }
 
 .site-nav {
   display: flex;
   align-items: center;
-  gap: 0.25rem;
-  padding: 0.26rem;
-  border-radius: 10px;
-  border: 1px solid rgba(136, 201, 255, 0.22);
-  background: rgba(8, 15, 24, 0.78);
-  position: relative;
-  z-index: 1;
+  gap: 0.1rem;
+  margin-left: auto;
 }
 
 .site-nav a {
-  text-decoration: none;
-  color: #a8bddb;
-  font-size: 0.88rem;
-  font-weight: 500;
-  font-family: var(--font-code);
-  padding: 0.48rem 0.76rem;
-  border-radius: 8px;
-  transition: color 0.24s ease, background 0.24s ease, box-shadow 0.24s ease;
+  font-size: 0.75rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  padding: 0.35rem 0.65rem;
+  border: 2px solid transparent;
+  display: block;
+  transition: border-color 0.1s, background 0.1s;
 }
 
 .site-nav a:hover,
-.site-nav a:focus-visible {
-  color: #f4fbff;
-  background: rgba(27, 238, 206, 0.1);
-}
-
 .site-nav a.active {
-  color: #04131a;
-  background: linear-gradient(120deg, #96f7e8, #63d4ff);
-  box-shadow: 0 6px 14px rgba(35, 197, 224, 0.3);
+  border-color: var(--border);
+  background: var(--bg-card);
 }
 
-.section {
-  padding: 7rem 0;
-  position: relative;
-}
-
-.wave-divider {
-  width: min(1280px, 96vw);
-  margin: -0.4rem auto 0;
-  opacity: 0.88;
-  pointer-events: none;
-}
-
-.wave-divider-canvas {
-  width: 100%;
-  height: auto;
-  display: block;
-  border-radius: 999px;
-  border: 1px solid rgba(120, 191, 255, 0.22);
-  background: linear-gradient(165deg, rgba(8, 16, 29, 0.88), rgba(7, 13, 24, 0.96));
-  box-shadow: 0 10px 28px rgba(4, 12, 28, 0.45);
-  animation: waveSurfacePulse 6.2s ease-in-out infinite;
-}
-
-.wave-panel {
-  margin-bottom: 1rem;
-}
-
-.eyebrow {
-  text-transform: none;
-  letter-spacing: 0.02em;
-  font-weight: 700;
-  font-size: 1.05rem;
-  font-family: var(--font-hand);
-  color: #7ef1cf;
-  margin: 0 0 0.8rem;
-}
-
-.eyebrow::before {
-  content: "// ";
-  color: #ffce7e;
-}
-
-h1,
-h2,
-h3 {
-  font-family: var(--font-code);
-  line-height: 1.15;
-  margin: 0;
-}
-
-p {
-  margin: 0;
-  color: var(--text-muted);
-}
-
+/* ── BUTTONS ─────────────────────────────────────────────────── */
 .btn {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  border-radius: 999px;
-  border: 1px solid transparent;
-  text-decoration: none;
-  font-weight: 700;
-  letter-spacing: 0.02em;
-  transition: transform 0.24s ease, box-shadow 0.24s ease, border-color 0.24s ease,
-    background 0.24s ease;
+  font-family: "Poppins", system-ui, sans-serif;
+  font-weight: 800;
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  padding: 0.7rem 1.5rem;
+  border: var(--bw) solid var(--border);
+  border-radius: 0;
   cursor: pointer;
+  text-decoration: none;
+  background: var(--yellow);
+  color: var(--text-main);
+  box-shadow: var(--shadow);
+  transition: transform 0.08s, box-shadow 0.08s;
+  white-space: nowrap;
 }
 
-.btn:hover,
-.btn:focus-visible {
-  transform: translateY(-1px);
+.btn:hover {
+  transform: translate(-2px, -2px);
+  box-shadow: 7px 7px 0 var(--border);
 }
 
-.btn-small {
-  min-height: 40px;
-  padding: 0 1rem;
-  font-size: 0.86rem;
+.btn:active {
+  transform: translate(3px, 3px);
+  box-shadow: 2px 2px 0 var(--border);
 }
 
 .btn-primary {
-  min-height: 46px;
-  padding: 0 1.3rem;
-  color: #021014;
-  background: linear-gradient(120deg, var(--teal), var(--cyan));
-  box-shadow: 0 14px 30px rgba(16, 206, 219, 0.3);
-}
-
-.btn-primary:hover,
-.btn-primary:focus-visible {
-  box-shadow: 0 20px 34px rgba(16, 206, 219, 0.38);
+  background: var(--text-main);
+  color: var(--yellow);
 }
 
 .btn-outline {
-  min-height: 46px;
-  padding: 0 1.3rem;
-  border-color: rgba(136, 200, 255, 0.45);
+  background: transparent;
   color: var(--text-main);
-  background: rgba(10, 20, 34, 0.58);
 }
 
-.btn-outline:hover,
-.btn-outline:focus-visible {
-  border-color: rgba(136, 200, 255, 0.8);
-}
-
-.btn-ghost {
-  border-color: rgba(136, 200, 255, 0.34);
-  color: var(--text-main);
-  background: rgba(4, 7, 15, 0.55);
+.btn-small {
+  padding: 0.4rem 1rem;
+  font-size: 0.7rem;
 }
 
 .header-cta {
-  min-height: 44px;
-  padding: 0 1.28rem;
-  border-color: rgba(145, 206, 255, 0.32);
-  background: rgba(11, 20, 30, 0.9);
-  color: #d9f4ff;
-  box-shadow: inset 0 0 0 1px rgba(186, 232, 255, 0.1), 0 10px 24px rgba(2, 16, 33, 0.3);
+  margin-left: 0.5rem;
 }
 
-.header-cta:hover,
-.header-cta:focus-visible {
-  border-color: rgba(168, 224, 255, 0.62);
-  background: rgba(13, 25, 37, 0.96);
+/* ── TYPOGRAPHY ─────────────────────────────────────────────── */
+h1,
+h2,
+h3 {
+  font-weight: 900;
+  line-height: 1.07;
+  margin: 0 0 0.75rem;
+  letter-spacing: -0.02em;
 }
 
-@keyframes logoFloat {
-  0%,
-  100% {
-    transform: translateY(0);
-  }
-  50% {
-    transform: translateY(-1.5px);
-  }
+h1 {
+  font-size: clamp(2.2rem, 5vw, 3.8rem);
 }
 
+h2 {
+  font-size: clamp(1.6rem, 3.5vw, 2.5rem);
+}
+
+h3 {
+  font-size: 1rem;
+  font-weight: 800;
+  letter-spacing: -0.01em;
+}
+
+p {
+  margin: 0 0 1rem;
+}
+
+.eyebrow {
+  font-size: 0.68rem;
+  font-weight: 800;
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+  background: var(--yellow);
+  color: var(--text-main);
+  display: inline-block;
+  padding: 0.25rem 0.65rem;
+  border: 2px solid var(--border);
+  margin-bottom: 0.75rem;
+}
+
+/* ── SECTION ─────────────────────────────────────────────────── */
+.section {
+  padding: 80px 0;
+}
+
+.section-head {
+  text-align: center;
+  max-width: 680px;
+  margin: 0 auto 3rem;
+}
+
+.section-head p:not(.eyebrow) {
+  font-size: 0.9rem;
+  color: var(--text-muted);
+}
+
+/* ── HERO ─────────────────────────────────────────────────────── */
 .hero {
-  padding-top: 6.2rem;
-  min-height: min(920px, 100svh);
-  overflow: hidden;
-}
-
-.hero::before {
-  content: "";
-  position: absolute;
-  inset: 0;
-  pointer-events: none;
-  background: radial-gradient(circle at 14% 46%, rgba(31, 238, 209, 0.2), rgba(31, 238, 209, 0)),
-    radial-gradient(circle at 86% 19%, rgba(255, 188, 98, 0.12), rgba(255, 188, 98, 0));
-}
-
-.hero::after {
-  content: "";
-  position: absolute;
-  left: -12%;
-  right: -12%;
-  top: -34%;
-  height: 74%;
-  background: linear-gradient(
-    115deg,
-    rgba(27, 240, 206, 0.08) 0%,
-    rgba(43, 200, 255, 0.05) 46%,
-    rgba(255, 145, 103, 0.08) 100%
-  );
-  filter: blur(30px);
-  pointer-events: none;
+  padding: 80px 0 60px;
+  background: var(--bg-main);
 }
 
 .hero-grid {
   display: grid;
-  grid-template-columns: 1.15fr 0.85fr;
-  gap: 2.2rem;
-  align-items: center;
-  position: relative;
-  z-index: 1;
+  grid-template-columns: 1fr 1fr;
+  gap: 3.5rem;
+  align-items: start;
 }
 
-.hero-copy {
-  position: relative;
-  border: 1px dashed rgba(125, 201, 255, 0.28);
-  border-radius: var(--radius-lg);
-  background: linear-gradient(165deg, rgba(11, 20, 30, 0.76), rgba(9, 16, 24, 0.92));
-  padding: 1rem 1rem 1.1rem;
-  box-shadow: 0 16px 32px rgba(2, 9, 18, 0.38);
-}
-
-.hero-copy::before {
-  content: "/* launch_block.ts */";
-  position: absolute;
-  top: -0.92rem;
-  left: 0.8rem;
-  padding: 0.12rem 0.45rem;
-  border: 1px solid rgba(129, 198, 255, 0.22);
-  background: rgba(8, 15, 23, 0.95);
-  color: #82edcb;
-  font-size: 0.88rem;
-  font-family: var(--font-hand);
-  letter-spacing: 0.01em;
-  border-radius: 8px;
+[data-hero-stagger] {
+  opacity: 0;
+  transform: translateY(18px);
 }
 
 .hero-kicker-row {
   display: flex;
+  gap: 0.4rem;
   flex-wrap: wrap;
-  gap: 0.45rem;
-  margin-bottom: 0.8rem;
+  margin-bottom: 0.85rem;
 }
 
 .hero-kicker-pill {
-  display: inline-flex;
-  align-items: center;
-  border-radius: 8px;
-  border: 1px dashed rgba(145, 210, 255, 0.3);
-  background: linear-gradient(145deg, rgba(8, 22, 39, 0.66), rgba(7, 15, 28, 0.86));
-  padding: 0.25rem 0.62rem;
-  font-size: 0.7rem;
+  font-size: 0.68rem;
   font-weight: 800;
-  letter-spacing: 0.04em;
-  text-transform: none;
-  color: #bde8ff;
-}
-
-.hero-kicker-pill::before {
-  content: "# ";
-  color: #ffce7e;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  padding: 0.25rem 0.65rem;
+  border: var(--bw) solid var(--border);
+  background: var(--blue);
+  color: #fff;
 }
 
 .hero-title {
-  font-size: clamp(2.2rem, 5vw, 4.3rem);
-  letter-spacing: -0.02em;
-  max-width: 13ch;
-  line-height: 1.08;
-  color: #dff4ff;
-  background: none;
-  text-shadow: 0 10px 34px rgba(46, 146, 223, 0.24);
-  position: relative;
-}
-
-.hero-title::before {
-  content: "<hero>";
-  display: block;
-  color: #74efc8;
-  font-size: 0.66rem;
-  letter-spacing: 0.1em;
-  margin-bottom: 0.42rem;
-}
-
-.hero-title::after {
-  content: " _";
-  color: #7decc9;
-  animation: heroCursor 1s steps(1, end) infinite;
+  font-size: clamp(2.4rem, 5.5vw, 4.2rem);
+  font-weight: 900;
+  line-height: 1.02;
+  margin-bottom: 1rem;
+  letter-spacing: -0.025em;
 }
 
 .hero-subtitle {
-  margin-top: 1.1rem;
-  max-width: 56ch;
-  font-size: 1.15rem;
-  color: #bfd0e9;
+  font-size: 0.95rem;
+  font-weight: 500;
+  color: var(--text-muted);
+  margin-bottom: 1.5rem;
+  line-height: 1.6;
 }
 
 .hero-proof {
-  margin-top: 1.25rem;
   display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 0.65rem;
+  grid-template-columns: 1fr 1fr;
+  gap: 0.85rem;
+  margin-bottom: 1.5rem;
 }
 
 .hero-proof-item {
-  border: 1px solid rgba(134, 195, 255, 0.22);
-  border-radius: 10px;
-  background: linear-gradient(165deg, rgba(8, 18, 33, 0.7), rgba(6, 13, 24, 0.9));
-  padding: 0.68rem 0.74rem 0.68rem 2.2rem;
-  position: relative;
-}
-
-.hero-proof {
-  counter-reset: proofblock;
-}
-
-.hero-proof-item::before {
-  counter-increment: proofblock;
-  content: counter(proofblock, decimal-leading-zero);
-  position: absolute;
-  left: 0.72rem;
-  top: 0.58rem;
-  color: #6dc2ff;
-  font-size: 0.72rem;
-  font-family: var(--font-code);
+  padding: 1rem;
+  border: var(--bw) solid var(--border);
+  background: var(--bg-card);
+  box-shadow: var(--shadow);
 }
 
 .hero-proof-title {
-  color: #eff8ff;
-  font-size: 0.79rem;
-  font-weight: 600;
-  margin-bottom: 0.28rem;
+  font-size: 0.75rem;
+  font-weight: 800;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin-bottom: 0.3rem;
+  padding-bottom: 0.3rem;
+  border-bottom: 2px solid var(--yellow);
 }
 
 .hero-proof-copy {
-  color: #9cb4ce;
-  font-size: 0.74rem;
-  line-height: 1.4;
+  font-size: 0.78rem;
+  color: var(--text-muted);
+  margin: 0;
+  line-height: 1.5;
 }
 
 .hero-cta {
   display: flex;
+  gap: 0.75rem;
   flex-wrap: wrap;
-  gap: 0.7rem;
-  margin-top: 1.25rem;
-}
-
-.hero-cta .btn-primary {
-  position: relative;
-  overflow: hidden;
-  box-shadow: 0 12px 26px rgba(16, 206, 219, 0.28), 0 0 30px rgba(43, 200, 255, 0.16);
-}
-
-.hero-cta .btn-primary::after {
-  content: "";
-  position: absolute;
-  top: -20%;
-  bottom: -20%;
-  width: 34%;
-  left: -42%;
-  background: linear-gradient(90deg, rgba(255, 255, 255, 0), rgba(255, 255, 255, 0.42), rgba(255, 255, 255, 0));
-  transform: skewX(-18deg);
-  animation: ctaSweep 3.5s ease-in-out infinite;
-}
-
-.hero-cta .btn-outline {
-  border-color: rgba(162, 213, 255, 0.52);
-  background: rgba(8, 18, 33, 0.82);
+  margin-bottom: 1.5rem;
 }
 
 .hero-metrics {
-  margin-top: 1.6rem;
   display: flex;
+  gap: 0.65rem;
   flex-wrap: wrap;
-  gap: 0.7rem;
 }
 
 .metric-chip {
-  flex: 1 1 180px;
   display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 1rem;
-  border: 1px solid rgba(132, 192, 255, 0.24);
-  border-radius: 9px;
-  background: linear-gradient(150deg, rgba(9, 19, 35, 0.82), rgba(6, 12, 24, 0.92));
-  padding: 0.7rem 0.9rem;
+  flex-direction: column;
+  padding: 0.7rem 1rem;
+  border: var(--bw) solid var(--border);
+  background: var(--yellow);
+  box-shadow: var(--shadow);
+  min-width: 110px;
 }
 
 .metric-value {
-  font-family: var(--font-code);
-  font-weight: 700;
-  color: var(--teal);
-  font-size: 1.35rem;
-  min-width: 2.8ch;
+  font-size: 1.75rem;
+  font-weight: 900;
+  line-height: 1;
+  letter-spacing: -0.03em;
 }
 
 .metric-label {
+  font-size: 0.65rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
   color: var(--text-muted);
-  font-size: 0.82rem;
+  margin-top: 0.2rem;
 }
 
+/* Hero visual */
 .hero-visual {
   position: relative;
-  min-height: 460px;
-  border-radius: var(--radius-lg);
-  border: 1px solid rgba(146, 210, 255, 0.24);
-  background: linear-gradient(165deg, rgba(14, 28, 44, 0.76), rgba(9, 16, 24, 0.95));
-  box-shadow: 0 22px 48px rgba(2, 11, 27, 0.56), inset 0 0 0 1px rgba(164, 225, 255, 0.05);
-  padding: 1.2rem;
-  overflow: hidden;
-}
-
-.hero-visual::before {
-  content: "";
-  position: absolute;
-  inset: 0;
-  background: radial-gradient(circle at 72% 18%, rgba(255, 191, 84, 0.16), rgba(255, 191, 84, 0)),
-    radial-gradient(circle at 32% 78%, rgba(25, 239, 208, 0.14), rgba(25, 239, 208, 0));
-  pointer-events: none;
-}
-
-#hero-wave {
-  width: 100%;
-  height: 100%;
-  display: block;
 }
 
 .hero-floating {
   position: absolute;
+  font-size: 0.65rem;
+  font-weight: 800;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  padding: 0.35rem 0.65rem;
+  border: var(--bw) solid var(--border);
   z-index: 2;
-  border-radius: 8px;
-  border: 1px dashed rgba(147, 206, 255, 0.3);
-  background: rgba(8, 16, 24, 0.86);
-  box-shadow: 0 8px 18px rgba(3, 12, 28, 0.34);
-  color: #dcf3ff;
-  font-size: 0.68rem;
-  font-weight: 600;
-  letter-spacing: 0.02em;
-  text-transform: none;
-  padding: 0.34rem 0.6rem;
+  white-space: nowrap;
 }
 
 .hero-floating-a {
-  top: 0.85rem;
-  left: 1rem;
+  top: 8%;
+  left: -4%;
+  background: var(--green);
+  color: var(--text-main);
+  box-shadow: 3px 3px 0 var(--border);
 }
 
 .hero-floating-b {
-  top: 0.85rem;
-  right: 1rem;
+  bottom: 14%;
+  right: -2%;
+  background: var(--blue);
+  color: #fff;
+  box-shadow: 3px 3px 0 var(--border);
+}
+
+#hero-wave {
+  width: 100%;
+  display: block;
+  border: var(--bw) solid var(--border);
 }
 
 .hero-glass {
-  position: absolute;
-  left: 1.2rem;
-  right: 1.2rem;
-  bottom: 1.2rem;
-  background: linear-gradient(160deg, rgba(5, 12, 25, 0.72), rgba(6, 15, 28, 0.84));
-  border: 1px solid rgba(132, 191, 255, 0.34);
-  border-radius: 16px;
-  padding: 0.85rem;
-  backdrop-filter: blur(10px);
+  border: var(--bw) solid var(--border);
+  border-top: none;
+  background: var(--bg-card);
+  box-shadow: var(--shadow);
+  padding: 1.1rem 1.25rem;
 }
 
 .glass-label {
-  font-size: 0.78rem;
+  font-size: 0.65rem;
+  font-weight: 800;
   text-transform: uppercase;
   letter-spacing: 0.12em;
-  color: #7fb8ff;
-  margin-bottom: 0.45rem;
+  margin-bottom: 0.65rem;
+  background: var(--yellow);
+  display: inline-block;
+  padding: 0.15rem 0.45rem;
+  border: 2px solid var(--border);
 }
 
 .live-feed {
   list-style: none;
   margin: 0;
   padding: 0;
-  display: grid;
-  gap: 0.45rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  font-size: 0.78rem;
+  font-weight: 600;
 }
 
 .live-feed li {
-  font-size: 0.9rem;
   display: flex;
   align-items: center;
-  gap: 0.65rem;
+  gap: 0.5rem;
+  padding: 0.35rem 0.55rem;
+  border: 2px solid var(--border);
+  background: var(--bg-main);
 }
 
 .feed-pill {
-  padding: 0.18rem 0.52rem;
-  border-radius: 999px;
-  font-size: 0.68rem;
+  font-size: 0.6rem;
   font-weight: 800;
   text-transform: uppercase;
   letter-spacing: 0.08em;
+  padding: 0.12rem 0.4rem;
+  border: 2px solid var(--border);
+  white-space: nowrap;
+  flex-shrink: 0;
 }
 
-.intent-hot {
-  color: #092017;
-  background: linear-gradient(145deg, #6bffca, #13f2d8);
+.intent-hot { background: var(--orange); color: #fff; }
+.intent-mid { background: var(--blue); color: #fff; }
+.intent-save { background: var(--green); color: var(--text-main); }
+
+/* ── WAVE DIVIDERS ─────────────────────────────────────────── */
+.wave-divider {
+  background: var(--bg-dark);
+  border-top: var(--bw) solid var(--border);
+  border-bottom: var(--bw) solid var(--border);
+  height: 80px;
+  overflow: hidden;
+  display: flex;
+  align-items: center;
 }
 
-.intent-mid {
-  color: #061a2a;
-  background: linear-gradient(145deg, #81dcff, #22c6ff);
+.wave-divider-canvas {
+  width: 100%;
+  display: block;
 }
 
-.intent-save {
-  color: #2a0903;
-  background: linear-gradient(145deg, #ffb093, #ff7f66);
-}
-
-.section-head {
-  max-width: 64ch;
+.wave-panel {
+  background: var(--bg-dark);
+  border: var(--bw) solid var(--border);
+  display: block;
+  width: 100%;
   margin-bottom: 2rem;
 }
 
-.section-head h2 {
-  font-size: clamp(1.65rem, 3.4vw, 3rem);
-  margin-bottom: 0.8rem;
-}
-
+/* ── PAIN GRID ─────────────────────────────────────────────── */
 .pain-grid {
   display: grid;
-  grid-template-columns: repeat(4, minmax(0, 1fr));
-  gap: 0.9rem;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 1.1rem;
 }
 
 .pain-card {
-  border: 1px solid rgba(125, 186, 255, 0.24);
-  border-radius: var(--radius-md);
+  padding: 1.4rem;
+  border: var(--bw) solid var(--border);
   background: var(--bg-card);
-  padding: 1.1rem;
-  min-height: 180px;
+  box-shadow: var(--shadow);
+  transition: transform 0.1s, box-shadow 0.1s;
+}
+
+.pain-card:hover {
+  transform: translate(-2px, -2px);
+  box-shadow: var(--shadow-lg);
 }
 
 .pain-card h3 {
-  font-size: 1.05rem;
+  font-size: 0.82rem;
+  font-weight: 900;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
   margin-bottom: 0.5rem;
+  padding-bottom: 0.4rem;
+  border-bottom: 3px solid var(--yellow);
 }
 
 .pain-card p {
-  font-size: 0.9rem;
+  font-size: 0.8rem;
+  color: var(--text-muted);
+  margin: 0;
+  line-height: 1.5;
 }
 
+/* ── LEGACY ─────────────────────────────────────────────────── */
 .legacy {
-  background: linear-gradient(180deg, rgba(8, 14, 28, 0.7), rgba(8, 14, 28, 0));
+  background: var(--bg-main);
 }
 
 .legacy-shell {
   display: grid;
   grid-template-columns: 1fr 1fr;
-  gap: 1rem;
+  border: var(--bw) solid var(--border);
+  box-shadow: var(--shadow-lg);
+  overflow: hidden;
 }
 
 .legacy-panel {
-  border: 1px solid rgba(138, 186, 255, 0.22);
-  border-radius: var(--radius-lg);
-  background: rgba(8, 16, 32, 0.78);
-  padding: 1.3rem;
-  min-height: 280px;
+  padding: 2rem;
+}
+
+.legacy-before {
+  background: var(--bg-card);
+  border-right: var(--bw) solid var(--border);
+}
+
+.legacy-after {
+  background: var(--bg-dark);
+  color: var(--yellow);
+}
+
+.legacy-panel h3 {
+  font-size: 0.8rem;
+  font-weight: 900;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  margin-bottom: 1.25rem;
+  padding-bottom: 0.5rem;
 }
 
 .legacy-before h3 {
-  color: #9ab6d9;
-}
-
-.legacy-after h3 {
-  color: var(--teal);
-}
-
-.legacy-panel ul {
-  margin: 1rem 0 0;
-  padding-left: 1.1rem;
-  color: var(--text-muted);
-  display: grid;
-  gap: 0.45rem;
-}
-
-.product-grid {
-  display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 1rem;
-}
-
-.product-card {
-  position: relative;
-  border-radius: var(--radius-lg);
-  border: 1px solid rgba(134, 190, 255, 0.24);
-  background: linear-gradient(155deg, rgba(13, 28, 52, 0.8), rgba(8, 14, 28, 0.92));
-  box-shadow: var(--shadow-glow);
-  overflow: hidden;
-  transform-style: preserve-3d;
-}
-
-.product-card::after {
-  content: "";
-  position: absolute;
-  inset: -2px;
-  border-radius: inherit;
-  opacity: 0;
-  transition: opacity 0.25s ease;
-  background: linear-gradient(115deg, rgba(19, 242, 216, 0.22), rgba(34, 198, 255, 0.02));
-}
-
-.product-card:hover::after,
-.product-card:focus-within::after {
-  opacity: 1;
-}
-
-.product-card-inner {
-  padding: 1.4rem;
-}
-
-.product-tag {
-  display: inline-flex;
-  padding: 0.28rem 0.58rem;
-  border-radius: 999px;
-  font-size: 0.68rem;
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
-  color: #061a2a;
-  background: linear-gradient(145deg, #9ef6ff, #45d8ff, #ffd28b);
-  margin-bottom: 0.95rem;
-  font-weight: 800;
-}
-
-.product-card h3 {
-  font-size: 1.55rem;
-  margin-bottom: 0.45rem;
-}
-
-.product-card p {
-  margin-bottom: 1rem;
-}
-
-.product-card ul {
-  margin: 0;
-  padding-left: 1.1rem;
-  display: grid;
-  gap: 0.38rem;
+  border-bottom: 3px solid var(--border);
   color: var(--text-main);
 }
 
-.product-detail {
-  padding-top: 5.6rem;
+.legacy-after h3 {
+  border-bottom: 3px solid var(--yellow);
+  color: var(--yellow);
+}
+
+.legacy-panel ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.65rem;
+}
+
+.legacy-panel li {
+  font-size: 0.84rem;
+  font-weight: 500;
+  padding: 0.4rem 0.5rem 0.4rem 1.5rem;
+  position: relative;
+  border: 2px solid transparent;
+}
+
+.legacy-before li {
+  background: var(--bg-main);
+  border-color: var(--border);
+}
+
+.legacy-after li {
+  background: rgba(255, 255, 255, 0.06);
+  border-color: rgba(255, 229, 0, 0.3);
+}
+
+.legacy-before li::before {
+  content: "✕";
+  position: absolute;
+  left: 0.4rem;
+  font-weight: 900;
+  color: var(--orange);
+  font-size: 0.75rem;
+}
+
+.legacy-after li::before {
+  content: "→";
+  position: absolute;
+  left: 0.4rem;
+  font-weight: 900;
+  color: var(--yellow);
+}
+
+/* ── PRODUCT CARDS ─────────────────────────────────────────── */
+.product-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1.5rem;
+}
+
+.product-card {
+  border: var(--bw) solid var(--border);
+  background: var(--bg-card);
+  box-shadow: var(--shadow-lg);
+  transition: transform 0.1s, box-shadow 0.1s;
+}
+
+.product-card:hover {
+  transform: translate(-3px, -3px);
+  box-shadow: 11px 11px 0 var(--border);
+}
+
+.product-card-inner {
+  padding: 2rem;
+}
+
+.product-tag {
+  font-size: 0.62rem;
+  font-weight: 800;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  padding: 0.2rem 0.5rem;
+  border: 2px solid var(--border);
+  background: var(--blue);
+  color: #fff;
+  display: inline-block;
+  margin-bottom: 0.85rem;
+}
+
+.product-card h3 {
+  font-size: 1.4rem;
+  font-weight: 900;
+  margin-bottom: 0.65rem;
+}
+
+.product-card p {
+  font-size: 0.84rem;
+  color: var(--text-muted);
+  margin-bottom: 1rem;
+  line-height: 1.6;
+}
+
+.product-card ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  border-top: var(--bw) solid var(--border);
+  padding-top: 1rem;
+}
+
+.product-card li {
+  font-size: 0.78rem;
+  font-weight: 600;
+  padding: 0.35rem 0.5rem 0.35rem 1.25rem;
+  position: relative;
+  border-left: 3px solid var(--yellow);
+  background: var(--bg-main);
+}
+
+.product-card li::before {
+  content: "→";
+  position: absolute;
+  left: 0.25rem;
+  font-weight: 900;
+  font-size: 0.7rem;
+}
+
+/* ── PRODUCT DETAILS ─────────────────────────────────────────── */
+.assist-detail {
+  background: var(--bg-main);
+}
+
+.voice-detail {
+  background: var(--bg-card);
 }
 
 .detail-grid {
   display: grid;
-  gap: 1.15rem;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
+  grid-template-columns: 1fr 1fr;
+  gap: 3rem;
+  align-items: start;
 }
 
-.detail-copy h2 {
-  font-size: clamp(1.75rem, 2.7vw, 2.6rem);
-  margin-bottom: 0.7rem;
+.detail-copy p:not(.eyebrow) {
+  font-size: 0.875rem;
+  color: var(--text-muted);
+  line-height: 1.65;
+  margin-bottom: 1.25rem;
 }
 
 .feature-list {
-  margin: 1rem 0 0;
-  padding-left: 1rem;
-  display: grid;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
   gap: 0.45rem;
-  color: var(--text-main);
+}
+
+.feature-list li {
+  font-size: 0.82rem;
+  font-weight: 600;
+  padding: 0.55rem 0.75rem 0.55rem 1.4rem;
+  position: relative;
+  border: 2px solid var(--border);
+  border-left: 4px solid var(--yellow);
+  background: var(--bg-card);
+  transition: background 0.1s;
+}
+
+.feature-list li::before {
+  content: "→";
+  position: absolute;
+  left: 0.3rem;
+  font-weight: 900;
+  font-size: 0.75rem;
+}
+
+.feature-list li:hover {
+  background: var(--yellow);
 }
 
 .detail-card {
-  border: 1px solid rgba(126, 179, 255, 0.24);
-  border-radius: var(--radius-lg);
-  background: linear-gradient(170deg, rgba(15, 31, 58, 0.78), rgba(8, 13, 24, 0.96));
-  padding: 1.2rem;
-  box-shadow: var(--shadow-glow);
-  transform-style: preserve-3d;
+  border: var(--bw) solid var(--border);
+  background: var(--bg-card);
+  box-shadow: var(--shadow-lg);
+  padding: 1.75rem;
 }
 
 .detail-card h3 {
-  margin-bottom: 1rem;
-  font-size: 1.25rem;
+  font-size: 0.75rem;
+  font-weight: 900;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  margin-bottom: 1.4rem;
+  padding-bottom: 0.6rem;
+  border-bottom: var(--bw) solid var(--border);
 }
 
+/* Signal meters */
 .signal-item {
-  display: grid;
-  gap: 0.42rem;
-  margin-bottom: 0.75rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  margin-bottom: 1.1rem;
 }
 
 .signal-item span {
-  font-size: 0.88rem;
-  color: #bfceea;
+  font-size: 0.72rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
 }
 
 .signal-meter {
-  height: 11px;
-  border-radius: 999px;
-  background: rgba(10, 22, 40, 0.9);
-  border: 1px solid rgba(132, 183, 255, 0.2);
+  height: 14px;
+  background: var(--bg-main);
+  border: 2px solid var(--border);
   overflow: hidden;
 }
 
 .signal-meter i {
   display: block;
   height: 100%;
-  width: var(--w);
-  background: linear-gradient(145deg, var(--teal), var(--cyan), var(--coral));
+  width: var(--w, 0%);
+  background: var(--text-main);
+  transition: width 1.2s ease;
 }
 
+/* Workflow list */
 .workflow-list {
   margin: 0;
-  padding-left: 1.1rem;
-  color: var(--text-main);
-  display: grid;
-  gap: 0.52rem;
+  padding: 0;
+  list-style: none;
+  counter-reset: wstep;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
 }
 
+.workflow-list li {
+  font-size: 0.84rem;
+  font-weight: 600;
+  padding: 0.7rem 0.8rem 0.7rem 3.2rem;
+  border: var(--bw) solid var(--border);
+  background: var(--bg-main);
+  position: relative;
+  counter-increment: wstep;
+  transition: background 0.1s;
+}
+
+.workflow-list li:hover {
+  background: var(--yellow);
+}
+
+.workflow-list li::before {
+  content: counter(wstep, decimal-leading-zero);
+  position: absolute;
+  left: 0;
+  top: 0;
+  bottom: 0;
+  width: 2.4rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--text-main);
+  color: var(--yellow);
+  font-size: 0.78rem;
+  font-weight: 900;
+  letter-spacing: -0.01em;
+}
+
+/* ── ASSIST LOOP ─────────────────────────────────────────────── */
+.assist-loop {
+  background: var(--bg-main);
+}
+
+.assist-loop-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 1.1rem;
+}
+
+.assist-loop-card {
+  border: var(--bw) solid var(--border);
+  background: var(--bg-card);
+  box-shadow: var(--shadow);
+  padding: 1.4rem;
+  transition: transform 0.1s, box-shadow 0.1s;
+}
+
+.assist-loop-card:hover {
+  transform: translate(-2px, -2px);
+  box-shadow: var(--shadow-lg);
+}
+
+.assist-kicker {
+  font-size: 0.6rem;
+  font-weight: 800;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  padding: 0.18rem 0.45rem;
+  border: 2px solid var(--border);
+  background: var(--orange);
+  color: #fff;
+  display: inline-block;
+  margin-bottom: 0.65rem;
+}
+
+.assist-loop-card h3 {
+  font-size: 0.82rem;
+  font-weight: 900;
+  margin-bottom: 0.35rem;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+}
+
+.assist-loop-card p {
+  font-size: 0.78rem;
+  color: var(--text-muted);
+  margin-bottom: 0.65rem;
+  line-height: 1.5;
+}
+
+.assist-metric {
+  font-size: 0.7rem;
+  font-weight: 800;
+  padding: 0.35rem 0.55rem;
+  background: var(--yellow);
+  border: 2px solid var(--border);
+  display: inline-block;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+/* ── LANGUAGE ─────────────────────────────────────────────── */
 .language-block {
-  margin-top: 1.1rem;
+  margin-top: 1.4rem;
+  border: var(--bw) solid var(--border);
+  padding: 1.25rem;
+  background: var(--bg-main);
 }
 
 .language-title {
-  color: #d0e2ff;
-  margin-bottom: 0.55rem;
+  font-size: 0.65rem;
+  font-weight: 800;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  margin-bottom: 0.65rem;
+  color: var(--text-muted);
 }
 
 .language-cloud {
   display: flex;
   flex-wrap: wrap;
-  gap: 0.45rem;
+  gap: 0.35rem;
 }
 
 .chip {
-  border: 1px solid rgba(124, 177, 255, 0.24);
-  background: rgba(8, 16, 30, 0.74);
-  color: #cae1ff;
-  border-radius: 999px;
-  padding: 0.3rem 0.56rem;
-  font-size: 0.75rem;
-}
-
-.assist-loop {
-  background: linear-gradient(180deg, rgba(8, 15, 28, 0), rgba(7, 13, 24, 0.68));
-}
-
-.assist-loop-grid {
-  display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
-  gap: 0.8rem;
-}
-
-.assist-loop-card {
-  border: 1px solid rgba(126, 187, 255, 0.24);
-  border-radius: var(--radius-md);
-  background: linear-gradient(155deg, rgba(10, 21, 39, 0.86), rgba(7, 13, 24, 0.96));
-  box-shadow: var(--shadow-glow);
-  padding: 1rem;
-}
-
-.assist-loop-card .assist-kicker {
-  display: inline-flex;
-  border-radius: 999px;
-  border: 1px solid rgba(158, 214, 255, 0.32);
-  background: rgba(9, 19, 33, 0.92);
-  color: #d2e9ff;
-  font-size: 0.7rem;
-  letter-spacing: 0.06em;
+  font-size: 0.65rem;
+  font-weight: 700;
+  padding: 0.2rem 0.45rem;
+  border: 2px solid var(--border);
+  background: var(--bg-card);
+  color: var(--text-main);
   text-transform: uppercase;
-  padding: 0.2rem 0.5rem;
-  margin-bottom: 0.55rem;
+  letter-spacing: 0.05em;
+  transition: background 0.1s;
 }
 
-.assist-loop-card h3 {
-  font-size: 1.05rem;
-  margin-bottom: 0.42rem;
+.chip:hover {
+  background: var(--yellow);
 }
 
-.assist-loop-card p {
-  font-size: 0.86rem;
-  margin-bottom: 0.68rem;
-}
-
-.assist-loop-card .assist-metric {
-  font-family: var(--font-code);
-  color: var(--teal);
-  font-size: 1.25rem;
-}
-
-.voice-demo .demo-grid {
-  display: grid;
-  grid-template-columns: 1fr;
-  gap: 1rem;
+/* ── VOICE DEMO ─────────────────────────────────────────────── */
+.voice-demo {
+  background: var(--bg-card);
 }
 
 .audio-card {
-  position: relative;
-  border: 1px solid rgba(130, 181, 255, 0.26);
-  border-radius: var(--radius-lg);
-  background: linear-gradient(170deg, rgba(14, 28, 52, 0.72), rgba(8, 13, 24, 0.95));
-  padding: 1rem;
-  box-shadow: var(--shadow-glow);
-  overflow: hidden;
-}
-
-.voice-demo .audio-card {
-  grid-column: 1;
-  width: min(760px, 100%);
+  border: var(--bw) solid var(--border);
+  background: var(--bg-main);
+  box-shadow: var(--shadow-lg);
+  padding: 2rem;
+  max-width: 740px;
   margin: 0 auto;
 }
 
-.audio-card::before {
-  content: "";
-  position: absolute;
-  inset: 0;
-  background: repeating-linear-gradient(
-    120deg,
-    rgba(34, 198, 255, 0.04) 0,
-    rgba(34, 198, 255, 0.04) 6px,
-    rgba(10, 21, 35, 0) 6px,
-    rgba(10, 21, 35, 0) 12px
-  );
-  background-size: 220% 220%;
-  animation: stripeFlow 9s linear infinite;
-  pointer-events: none;
-}
-
-.audio-card > * {
-  position: relative;
-  z-index: 1;
+.audio-header {
+  margin-bottom: 1.25rem;
+  padding-bottom: 0.85rem;
+  border-bottom: var(--bw) solid var(--border);
 }
 
 .audio-header h3 {
-  margin-bottom: 0.35rem;
+  font-size: 0.85rem;
+  font-weight: 900;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  margin-bottom: 0.2rem;
+}
+
+.audio-header p {
+  font-size: 0.75rem;
+  color: var(--text-muted);
+  margin: 0;
 }
 
 #audio-visualizer {
-  margin-top: 0.9rem;
   width: 100%;
-  height: auto;
+  border: var(--bw) solid var(--border);
   display: block;
-  border-radius: 14px;
-  border: 1px solid rgba(139, 206, 255, 0.24);
-  background: linear-gradient(165deg, rgba(4, 8, 15, 0.92), rgba(8, 19, 33, 0.88));
+  margin-bottom: 1.25rem;
+  background: var(--bg-dark);
 }
 
 .audio-controls {
-  margin-top: 0.85rem;
-  display: grid;
-  gap: 0.55rem;
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  margin-bottom: 1.1rem;
+  flex-wrap: wrap;
 }
 
 #seek-slider {
-  width: 100%;
-  accent-color: var(--teal);
+  flex: 1;
+  min-width: 100px;
+  cursor: pointer;
+  height: 10px;
+  border: var(--bw) solid var(--border);
+  border-radius: 0;
+  background: var(--bg-card);
+  appearance: none;
+  -webkit-appearance: none;
+  outline: none;
+}
+
+#seek-slider::-webkit-slider-thumb {
+  -webkit-appearance: none;
+  width: 18px;
+  height: 18px;
+  background: var(--text-main);
+  border: 2px solid var(--text-main);
+  border-radius: 0;
+  cursor: pointer;
+}
+
+#seek-slider::-moz-range-thumb {
+  width: 18px;
+  height: 18px;
+  background: var(--text-main);
+  border: 2px solid var(--text-main);
+  border-radius: 0;
+  cursor: pointer;
 }
 
 .audio-time {
   display: flex;
-  justify-content: space-between;
-  font-variant-numeric: tabular-nums;
-  color: #bdd6fb;
-  font-size: 0.82rem;
+  gap: 0.2rem;
+  font-size: 0.75rem;
+  font-weight: 800;
+  font-family: monospace;
+  padding: 0.3rem 0.55rem;
+  border: var(--bw) solid var(--border);
+  background: var(--bg-card);
+  white-space: nowrap;
 }
 
 .segment-jumps,
 .accent-row {
-  margin-top: 0.95rem;
+  margin-bottom: 1.1rem;
 }
 
-.segment-jumps p,
-.accent-row p {
-  color: #bed6fa;
-  font-size: 0.83rem;
-  margin-bottom: 0.4rem;
+.segment-jumps > p,
+.accent-row > p {
+  font-size: 0.65rem;
+  font-weight: 800;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  margin-bottom: 0.45rem;
+  color: var(--text-muted);
 }
 
 .segment-row {
   display: flex;
   flex-wrap: wrap;
-  gap: 0.4rem;
-}
-
-.segment-btn {
-  border: 1px solid rgba(126, 180, 255, 0.28);
-  border-radius: 999px;
-  padding: 0.28rem 0.58rem;
-  background: rgba(7, 13, 24, 0.88);
-  color: #d2e6ff;
-  cursor: pointer;
-  font-size: 0.76rem;
-}
-
-.segment-btn:hover,
-.segment-btn:focus-visible {
-  border-color: rgba(162, 209, 255, 0.65);
-}
-
-.segment-btn.active {
-  background: linear-gradient(145deg, #82f8e6, #2ac6ff);
-  color: #04111d;
-  border-color: transparent;
-}
-
-.transcript-strip {
-  margin-top: 0.95rem;
-  display: grid;
   gap: 0.35rem;
 }
 
+.segment-btn {
+  font-family: "Poppins", system-ui, sans-serif;
+  font-size: 0.68rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  padding: 0.28rem 0.6rem;
+  border: var(--bw) solid var(--border);
+  background: var(--bg-card);
+  color: var(--text-main);
+  cursor: pointer;
+  transition: background 0.08s;
+  border-radius: 0;
+}
+
+.segment-btn:hover {
+  background: var(--yellow);
+}
+
+.segment-btn.active {
+  background: var(--text-main);
+  color: var(--yellow);
+}
+
+.transcript-strip {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  margin-top: 1rem;
+  border-top: var(--bw) solid var(--border);
+  padding-top: 1rem;
+}
+
 .transcript-item {
-  border: 1px solid rgba(118, 171, 244, 0.2);
-  border-radius: 12px;
-  padding: 0.55rem 0.65rem;
-  background: rgba(7, 14, 27, 0.85);
-  color: #d3e7ff;
-  font-size: 0.82rem;
+  font-family: "Poppins", system-ui, sans-serif;
+  font-size: 0.78rem;
+  font-weight: 500;
+  padding: 0.5rem 0.75rem;
+  border: 2px solid var(--border);
+  background: var(--bg-card);
+  color: var(--text-main);
+  cursor: pointer;
+  text-align: left;
+  transition: background 0.08s;
+  border-radius: 0;
+}
+
+.transcript-item:hover {
+  background: var(--yellow);
+}
+
+/* ── BENCHMARKS ─────────────────────────────────────────────── */
+.benchmark-spotlight {
+  display: grid;
+  grid-template-columns: 2fr 1fr 1fr;
+  gap: 1.1rem;
+  margin-bottom: 1.5rem;
+}
+
+.spotlight-card {
+  border: var(--bw) solid var(--border);
+  background: var(--bg-card);
+  box-shadow: var(--shadow);
+  padding: 1.4rem;
+  transition: transform 0.1s, box-shadow 0.1s;
+}
+
+.spotlight-card:hover {
+  transform: translate(-2px, -2px);
+  box-shadow: var(--shadow-lg);
+}
+
+.spotlight-card.primary {
+  background: var(--bg-dark);
+  color: var(--yellow);
+}
+
+.spotlight-label {
+  font-size: 0.65rem;
+  font-weight: 800;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  margin-bottom: 0.4rem;
+  opacity: 0.7;
+}
+
+.spotlight-value {
+  font-size: 2.1rem;
+  font-weight: 900;
+  line-height: 1;
+  margin-bottom: 0.4rem;
+  letter-spacing: -0.025em;
+}
+
+.spotlight-note {
+  font-size: 0.73rem;
+  font-weight: 500;
+  opacity: 0.7;
+  margin: 0;
+  line-height: 1.4;
 }
 
 .benchmark-grid {
   display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
-  gap: 1rem;
-  margin-top: 1rem;
-}
-
-#benchmarks {
-  position: relative;
-}
-
-#benchmarks::before {
-  content: "";
-  position: absolute;
-  inset: 0;
-  pointer-events: none;
-  background: radial-gradient(circle at 18% 24%, rgba(25, 239, 208, 0.14), rgba(25, 239, 208, 0)),
-    radial-gradient(circle at 82% 78%, rgba(255, 140, 97, 0.12), rgba(255, 140, 97, 0));
-}
-
-.benchmark-spotlight {
-  position: relative;
-  z-index: 1;
-  display: grid;
-  grid-template-columns: 1.55fr 1fr 1fr;
-  gap: 0.8rem;
-}
-
-.spotlight-card {
-  border-radius: var(--radius-md);
-  border: 1px solid rgba(130, 191, 255, 0.26);
-  background: linear-gradient(155deg, rgba(10, 21, 38, 0.86), rgba(7, 14, 25, 0.94));
-  box-shadow: var(--shadow-glow);
-  padding: 1rem;
-}
-
-.spotlight-card.primary {
-  border-color: rgba(122, 233, 218, 0.45);
-  background: linear-gradient(160deg, rgba(9, 30, 42, 0.9), rgba(7, 14, 25, 0.98));
-}
-
-.spotlight-label {
-  color: #cae4ff;
-  font-size: 0.8rem;
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
-}
-
-.spotlight-value {
-  font-family: var(--font-code);
-  font-size: clamp(1.65rem, 3.6vw, 2.8rem);
-  line-height: 1.1;
-  margin: 0.4rem 0 0.3rem;
-  background: linear-gradient(100deg, #f2fbff, #9cecff 45%, #9effd6 75%, #ffd5a0);
-  -webkit-background-clip: text;
-  background-clip: text;
-  color: transparent;
-}
-
-.spotlight-note {
-  color: #a7bdd8;
-  font-size: 0.82rem;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 1.1rem;
 }
 
 .benchmark-card {
-  position: relative;
-  overflow: hidden;
-  border: 1px solid rgba(129, 188, 255, 0.27);
-  border-radius: var(--radius-md);
-  background: linear-gradient(160deg, rgba(8, 18, 34, 0.9), rgba(7, 13, 24, 0.96));
-  padding: 1rem;
-  min-height: 235px;
-  transition: transform 0.26s ease, box-shadow 0.26s ease, border-color 0.26s ease;
+  border: var(--bw) solid var(--border);
+  background: var(--bg-card);
+  box-shadow: var(--shadow);
+  padding: 1.4rem;
+  transition: transform 0.1s, box-shadow 0.1s;
 }
 
-.benchmark-card::before {
-  content: "";
-  position: absolute;
-  inset: 0;
-  background: linear-gradient(
-    120deg,
-    rgba(25, 239, 208, 0.08) 0%,
-    rgba(25, 239, 208, 0) 45%,
-    rgba(255, 140, 97, 0.12) 100%
-  );
-  opacity: 0;
-  transition: opacity 0.24s ease;
-  pointer-events: none;
-}
-
-.benchmark-card:hover,
-.benchmark-card:focus-within {
-  transform: translateY(-3px);
-  border-color: rgba(168, 222, 255, 0.42);
-  box-shadow: 0 24px 40px rgba(2, 12, 29, 0.52);
-}
-
-.benchmark-card:hover::before,
-.benchmark-card:focus-within::before {
-  opacity: 1;
-}
-
-.benchmark-card[data-priority="high"] {
-  border-color: rgba(106, 232, 214, 0.45);
-  box-shadow: 0 20px 38px rgba(7, 28, 42, 0.56);
-}
-
-.benchmark-card[data-priority="high"] .benchmark-kpi {
-  font-size: 2.15rem;
+.benchmark-card:hover {
+  transform: translate(-2px, -2px);
+  box-shadow: var(--shadow-lg);
 }
 
 .benchmark-topline {
   display: flex;
-  align-items: center;
-  justify-content: space-between;
-  margin-bottom: 0.5rem;
-}
-
-.benchmark-badge,
-.benchmark-signal {
-  font-size: 0.68rem;
-  text-transform: uppercase;
-  letter-spacing: 0.09em;
-  border-radius: 999px;
-  padding: 0.2rem 0.48rem;
+  gap: 0.4rem;
+  flex-wrap: wrap;
+  margin-bottom: 0.65rem;
 }
 
 .benchmark-badge {
-  color: #03141a;
+  font-size: 0.6rem;
   font-weight: 800;
-  background: linear-gradient(140deg, #9ef9ed, #74d9ff);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  padding: 0.18rem 0.45rem;
+  border: 2px solid var(--border);
+  background: var(--yellow);
+  color: var(--text-main);
 }
 
 .benchmark-signal {
-  color: #b7d8ff;
-  border: 1px solid rgba(136, 194, 255, 0.3);
-  background: rgba(10, 21, 37, 0.86);
+  font-size: 0.6rem;
+  font-weight: 800;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  padding: 0.18rem 0.45rem;
+  border: 2px solid var(--border);
+  background: var(--bg-main);
+  color: var(--text-main);
 }
 
 .benchmark-kpi {
-  font-family: var(--font-code);
-  font-size: 1.9rem;
-  color: var(--teal);
-  margin-bottom: 0.45rem;
-  line-height: 1.08;
-  text-shadow: 0 0 30px rgba(25, 239, 208, 0.35);
+  font-size: 1.85rem;
+  font-weight: 900;
+  line-height: 1;
+  margin-bottom: 0.35rem;
+  letter-spacing: -0.025em;
 }
 
 .benchmark-card h3 {
-  font-size: 1.05rem;
-  margin-bottom: 0.45rem;
-  color: #ebf5ff;
+  font-size: 0.75rem;
+  font-weight: 900;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  margin-bottom: 0.35rem;
 }
 
 .benchmark-card p {
-  font-size: 0.9rem;
-  color: #bad0e8;
+  font-size: 0.76rem;
+  color: var(--text-muted);
+  margin-bottom: 0.65rem;
+  line-height: 1.5;
 }
 
 .bar-track {
-  margin-top: 0.85rem;
   height: 10px;
-  border-radius: 999px;
-  border: 1px solid rgba(113, 175, 244, 0.2);
-  background: rgba(9, 18, 33, 0.96);
+  background: var(--bg-main);
+  border: 2px solid var(--border);
   overflow: hidden;
 }
 
 .bar-track i {
   display: block;
   height: 100%;
-  width: 0%;
-  border-radius: inherit;
-  background: linear-gradient(145deg, var(--teal), var(--cyan), var(--coral));
+  width: 0;
+  background: var(--text-main);
+  transition: width 1.2s ease;
 }
 
+/* ── INTEGRATIONS ─────────────────────────────────────────────── */
 .integrations {
-  background: linear-gradient(180deg, rgba(7, 13, 25, 0), rgba(8, 14, 26, 0.72));
+  background: var(--bg-main);
 }
 
 .stack-strip {
-  display: grid;
-  grid-template-columns: repeat(5, minmax(0, 1fr));
-  gap: 0.55rem;
-  margin-bottom: 1rem;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.65rem;
+  justify-content: center;
+  margin-bottom: 2.5rem;
 }
 
 .stack-strip span {
-  border: 1px solid rgba(132, 181, 255, 0.24);
-  border-radius: 14px;
-  text-align: center;
-  padding: 0.62rem;
-  background: rgba(8, 15, 27, 0.78);
-  font-size: 0.86rem;
-  color: #d0e4fe;
+  font-size: 0.72rem;
+  font-weight: 800;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  padding: 0.5rem 1.2rem;
+  border: var(--bw) solid var(--border);
+  background: var(--bg-card);
+  box-shadow: 4px 4px 0 var(--border);
+  transition: transform 0.1s, box-shadow 0.1s, background 0.1s;
+  cursor: default;
+}
+
+.stack-strip span:hover {
+  transform: translate(-2px, -2px);
+  box-shadow: 6px 6px 0 var(--border);
+  background: var(--yellow);
 }
 
 .timeline-grid {
   display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
-  gap: 0.75rem;
+  grid-template-columns: repeat(3, 1fr);
+  border: var(--bw) solid var(--border);
+  box-shadow: var(--shadow-lg);
 }
 
 .timeline-grid article {
-  border: 1px solid rgba(131, 182, 255, 0.24);
-  border-radius: var(--radius-md);
-  background: rgba(7, 14, 27, 0.82);
-  padding: 1rem;
+  padding: 1.75rem;
+  border-right: var(--bw) solid var(--border);
+  background: var(--bg-card);
+  transition: background 0.1s;
+}
+
+.timeline-grid article:last-child {
+  border-right: none;
+}
+
+.timeline-grid article:hover {
+  background: var(--yellow);
 }
 
 .timeline-grid h3 {
-  margin-bottom: 0.42rem;
-  color: #d9ecff;
+  font-size: 0.8rem;
+  font-weight: 900;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  margin-bottom: 0.65rem;
+  padding-bottom: 0.45rem;
+  border-bottom: var(--bw) solid var(--border);
+}
+
+.timeline-grid p {
+  font-size: 0.8rem;
+  color: var(--text-muted);
+  margin: 0;
+  line-height: 1.55;
+}
+
+/* ── GUARDRAILS ─────────────────────────────────────────────── */
+.guardrails {
+  background: var(--bg-card);
 }
 
 .guardrail-grid {
   display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
-  gap: 0.8rem;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 1.1rem;
 }
 
 .guardrail-grid article {
-  border: 1px solid rgba(132, 181, 255, 0.24);
-  border-radius: var(--radius-md);
-  background: rgba(7, 13, 25, 0.8);
-  padding: 1rem;
+  border: var(--bw) solid var(--border);
+  background: var(--bg-main);
+  box-shadow: var(--shadow);
+  padding: 1.5rem;
+  transition: transform 0.1s, box-shadow 0.1s, background 0.1s;
+}
+
+.guardrail-grid article:hover {
+  transform: translate(-2px, -2px);
+  box-shadow: var(--shadow-lg);
+  background: var(--yellow);
 }
 
 .guardrail-grid h3 {
-  margin-bottom: 0.42rem;
-  color: #d7eaff;
+  font-size: 0.8rem;
+  font-weight: 900;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  margin-bottom: 0.45rem;
+  padding-bottom: 0.4rem;
+  border-bottom: 3px solid var(--orange);
+}
+
+.guardrail-grid p {
+  font-size: 0.8rem;
+  color: var(--text-muted);
+  margin: 0;
+  line-height: 1.5;
+}
+
+/* ── FAQ ─────────────────────────────────────────────────────── */
+.faq {
+  background: var(--bg-main);
 }
 
 .faq-list {
-  display: grid;
-  gap: 0.6rem;
+  max-width: 720px;
+  margin: 0 auto;
+  display: flex;
+  flex-direction: column;
 }
 
 .faq-item {
-  border: 1px solid rgba(131, 181, 255, 0.23);
-  border-radius: 14px;
-  background: rgba(7, 13, 25, 0.82);
-  padding: 0.1rem 0.8rem;
+  border: var(--bw) solid var(--border);
+  margin-top: -3px;
+  background: var(--bg-card);
+}
+
+.faq-item[open] {
+  background: var(--yellow);
 }
 
 .faq-item summary {
+  font-size: 0.84rem;
+  font-weight: 800;
+  padding: 1rem 1.25rem;
   cursor: pointer;
   list-style: none;
-  padding: 0.85rem 0;
-  font-weight: 700;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
 }
 
 .faq-item summary::-webkit-details-marker {
   display: none;
 }
 
-.faq-item p {
-  padding: 0 0 0.95rem;
+.faq-item summary::marker {
+  display: none;
 }
 
+.faq-item summary::after {
+  content: "+";
+  font-size: 1.2rem;
+  font-weight: 900;
+  flex-shrink: 0;
+  margin-left: 1rem;
+}
+
+.faq-item[open] summary::after {
+  content: "−";
+}
+
+.faq-item p {
+  margin: 0;
+  padding: 0.85rem 1.25rem 1.1rem;
+  font-size: 0.84rem;
+  color: var(--text-muted);
+  border-top: 2px solid var(--border);
+  line-height: 1.6;
+}
+
+/* ── CTA ─────────────────────────────────────────────────────── */
 .cta {
-  padding-top: 6rem;
+  background: var(--bg-dark);
+  color: var(--text-inv);
 }
 
 .cta-grid {
   display: grid;
   grid-template-columns: 1fr 1fr;
-  gap: 1rem;
+  gap: 4rem;
   align-items: start;
 }
 
-.cta-copy h2 {
-  font-size: clamp(1.8rem, 3vw, 2.7rem);
-  margin-bottom: 0.7rem;
-}
-
-.cta-bullets {
-  margin: 1.2rem 0 0;
-  padding-left: 1.1rem;
-  display: grid;
-  gap: 0.42rem;
+.cta .eyebrow {
+  background: var(--yellow);
   color: var(--text-main);
 }
 
+.cta h2 {
+  color: var(--yellow);
+}
+
+.cta-copy p {
+  color: rgba(255, 254, 240, 0.7);
+  font-size: 0.875rem;
+  line-height: 1.65;
+}
+
+.cta-bullets {
+  list-style: none;
+  margin: 1rem 0 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.45rem;
+}
+
+.cta-bullets li {
+  font-size: 0.84rem;
+  font-weight: 500;
+  padding: 0.45rem 0.75rem 0.45rem 1.5rem;
+  position: relative;
+  color: rgba(255, 254, 240, 0.8);
+  border: 2px solid rgba(255, 229, 0, 0.25);
+  background: rgba(255, 229, 0, 0.06);
+}
+
+.cta-bullets li::before {
+  content: "→";
+  position: absolute;
+  left: 0.4rem;
+  color: var(--yellow);
+  font-weight: 900;
+}
+
+/* ── DEMO FORM ─────────────────────────────────────────────── */
 .demo-form {
-  border: 1px solid rgba(133, 183, 255, 0.26);
-  border-radius: var(--radius-lg);
-  background: linear-gradient(170deg, rgba(13, 25, 46, 0.82), rgba(7, 13, 24, 0.96));
-  box-shadow: var(--shadow-glow);
-  padding: 1rem;
-  display: grid;
-  gap: 0.35rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  border: var(--bw) solid var(--yellow);
+  padding: 1.75rem;
+  box-shadow: 8px 8px 0 var(--yellow);
+  background: var(--bg-card);
 }
 
 .demo-form label {
-  font-size: 0.82rem;
-  color: #d5e8ff;
-  margin-top: 0.3rem;
+  font-size: 0.65rem;
+  font-weight: 800;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: var(--text-main);
+  margin-bottom: -0.35rem;
 }
 
 .demo-form input,
 .demo-form select,
 .demo-form textarea {
-  width: 100%;
-  border-radius: 12px;
-  border: 1px solid rgba(127, 177, 248, 0.28);
-  background: rgba(5, 11, 21, 0.9);
+  font-family: "Poppins", system-ui, sans-serif;
+  font-size: 0.84rem;
+  font-weight: 500;
+  padding: 0.65rem 0.85rem;
+  border: var(--bw) solid var(--text-main);
+  border-radius: 0;
+  background: var(--bg-main);
   color: var(--text-main);
-  padding: 0.62rem 0.72rem;
-  font: inherit;
+  outline: none;
+  width: 100%;
+  transition: border-color 0.1s, box-shadow 0.1s;
 }
 
-.demo-form input:focus-visible,
-.demo-form select:focus-visible,
-.demo-form textarea:focus-visible {
-  outline: 2px solid rgba(20, 233, 213, 0.4);
-  outline-offset: 1px;
+.demo-form input:focus,
+.demo-form select:focus,
+.demo-form textarea:focus {
+  border-color: var(--blue);
+  box-shadow: 3px 3px 0 var(--blue);
+}
+
+.demo-form textarea {
+  resize: vertical;
+}
+
+.demo-form button[type="submit"] {
+  width: 100%;
 }
 
 .honey-input {
-  position: absolute;
-  left: -9999px;
+  display: none;
 }
 
 .form-note {
-  margin-top: 0.5rem;
-  font-size: 0.82rem;
+  font-size: 0.7rem;
+  color: var(--text-muted);
+  margin: 0;
+  text-align: center;
 }
 
 .form-note a {
-  color: #9ce6ff;
+  color: var(--blue);
+  text-decoration: underline;
+  font-weight: 700;
 }
 
+/* ── FOOTER ─────────────────────────────────────────────────── */
 .site-footer {
-  border-top: 1px solid rgba(131, 181, 255, 0.2);
-  padding: 1.2rem 0 1.8rem;
+  background: var(--bg-dark);
+  color: var(--text-inv);
+  padding: 2rem 0;
+  border-top: var(--bw) solid var(--border);
 }
 
 .footer-inner {
   display: flex;
-  flex-wrap: wrap;
   justify-content: space-between;
+  align-items: center;
+  flex-wrap: wrap;
   gap: 0.75rem;
 }
 
 .footer-inner p {
+  font-size: 0.75rem;
+  font-weight: 700;
   margin: 0;
-  font-size: 0.82rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  opacity: 0.65;
 }
 
+/* ── TOAST ─────────────────────────────────────────────────── */
 .toast {
   position: fixed;
-  right: 1rem;
-  bottom: 1rem;
-  max-width: min(380px, 90vw);
-  padding: 0.72rem 0.9rem;
-  border-radius: 12px;
-  border: 1px solid rgba(136, 197, 255, 0.3);
-  background: rgba(6, 12, 22, 0.94);
-  color: #dff1ff;
-  opacity: 0;
-  transform: translateY(8px);
+  bottom: 1.5rem;
+  left: 50%;
+  transform: translateX(-50%) translateY(140%);
+  background: var(--bg-dark);
+  color: var(--yellow);
+  font-size: 0.78rem;
+  font-weight: 800;
+  padding: 0.8rem 1.4rem;
+  border: var(--bw) solid var(--yellow);
+  box-shadow: var(--shadow);
+  z-index: 9999;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  max-width: min(460px, 90vw);
+  text-align: center;
+  transition: transform 0.25s cubic-bezier(0.34, 1.56, 0.64, 1);
   pointer-events: none;
-  transition: opacity 0.24s ease, transform 0.24s ease;
-  font-size: 0.83rem;
-  z-index: 40;
 }
 
 .toast.show {
-  opacity: 1;
-  transform: translateY(0);
+  transform: translateX(-50%) translateY(0);
 }
 
 .toast.error {
-  border-color: rgba(255, 132, 120, 0.58);
+  border-color: var(--orange);
+  color: var(--orange);
 }
 
-[data-reveal],
-[data-hero-stagger] {
-  opacity: 0;
-  transform: translateY(24px);
-}
-
-@keyframes waveSurfacePulse {
-  0%,
-  100% {
-    box-shadow: 0 10px 28px rgba(4, 12, 28, 0.45);
-    filter: saturate(1);
+/* ── RESPONSIVE ─────────────────────────────────────────────── */
+@media (max-width: 1000px) {
+  .pain-grid {
+    grid-template-columns: repeat(2, 1fr);
   }
-  50% {
-    box-shadow: 0 14px 34px rgba(9, 34, 61, 0.54);
-    filter: saturate(1.15);
+
+  .assist-loop-grid {
+    grid-template-columns: repeat(2, 1fr);
   }
 }
 
-@keyframes stripeFlow {
-  0% {
-    background-position: 0% 0%;
-  }
-  100% {
-    background-position: 180% 0%;
-  }
-}
-
-@keyframes ctaSweep {
-  0% {
-    left: -42%;
-  }
-  52% {
-    left: 118%;
-  }
-  100% {
-    left: 118%;
-  }
-}
-
-@keyframes heroCursor {
-  0%,
-  49% {
-    opacity: 1;
-  }
-  50%,
-  100% {
-    opacity: 0;
-  }
-}
-
-@media (max-width: 1160px) {
-  .benchmark-spotlight {
-    grid-template-columns: 1fr 1fr;
-  }
-
-  .spotlight-card.primary {
-    grid-column: 1 / -1;
-  }
-
-  .benchmark-grid {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-  }
-}
-
-@media (max-width: 940px) {
-  .site-nav,
-  .header-inner > .btn {
-    display: none;
-  }
-
-  .site-header {
-    padding-top: 0.45rem;
-  }
-
-  .header-inner {
-    min-height: 66px;
-    border-radius: 20px;
-    padding: 0.35rem 0.55rem;
-  }
-
-  .brand-logo {
-    width: 40px;
-    height: 40px;
-  }
-
-  .brand-sub {
-    display: none;
-  }
-
-  .hero {
-    padding-top: 5.5rem;
-    min-height: auto;
-  }
-
-  .hero-proof {
-    grid-template-columns: 1fr;
-  }
-
+@media (max-width: 860px) {
   .hero-grid,
   .detail-grid,
-  .voice-demo .demo-grid,
   .cta-grid {
     grid-template-columns: 1fr;
-  }
-
-  .voice-demo .audio-card {
-    grid-column: auto;
-  }
-
-  .hero-visual {
-    min-height: 360px;
-  }
-
-  .pain-grid,
-  .product-grid,
-  .assist-loop-grid,
-  .timeline-grid,
-  .guardrail-grid {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-  }
-
-  .benchmark-grid {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-  }
-
-  .stack-strip {
-    grid-template-columns: repeat(3, minmax(0, 1fr));
-  }
-}
-
-@media (max-width: 640px) {
-  .section {
-    padding: 5.3rem 0;
-  }
-
-  .hero-title {
-    font-size: clamp(1.8rem, 11vw, 2.7rem);
-  }
-
-  .hero-kicker-row {
-    margin-bottom: 0.55rem;
-  }
-
-  .hero-kicker-pill {
-    font-size: 0.66rem;
-    padding: 0.22rem 0.5rem;
-  }
-
-  .hero-subtitle {
-    font-size: 1rem;
-  }
-
-  .hero-proof-item {
-    padding: 0.62rem 0.66rem;
-  }
-
-  .hero-proof-title {
-    font-size: 0.78rem;
-  }
-
-  .hero-proof-copy {
-    font-size: 0.72rem;
-  }
-
-  .hero-floating {
-    font-size: 0.63rem;
-    padding: 0.26rem 0.46rem;
-  }
-
-  .hero-floating-a {
-    left: 0.66rem;
-    top: 0.66rem;
-  }
-
-  .hero-floating-b {
-    display: none;
-  }
-
-  .header-inner {
-    min-height: 62px;
-    padding: 0.3rem 0.5rem;
-  }
-
-  .brand {
-    gap: 0.58rem;
-  }
-
-  .brand-logo {
-    width: 36px;
-    height: 36px;
-  }
-
-  .brand-text {
-    font-size: 0.98rem;
-    letter-spacing: 0.09em;
-  }
-
-  .pain-grid,
-  .product-grid,
-  .assist-loop-grid,
-  .timeline-grid,
-  .guardrail-grid,
-  .benchmark-spotlight,
-  .benchmark-grid,
-  .stack-strip {
-    grid-template-columns: 1fr;
-  }
-
-  .wave-divider {
-    width: 94vw;
   }
 
   .legacy-shell {
     grid-template-columns: 1fr;
   }
 
-  .metric-chip {
-    flex-direction: column;
-    align-items: flex-start;
-    gap: 0.15rem;
+  .legacy-before {
+    border-right: none;
+    border-bottom: var(--bw) solid var(--border);
   }
 
-  .hero-visual {
-    min-height: 300px;
-  }
-
-  .footer-inner {
-    flex-direction: column;
-  }
-}
-
-@media (prefers-reduced-motion: reduce) {
-  html {
-    scroll-behavior: auto;
-  }
-
-  *,
-  *::before,
-  *::after {
-    animation-duration: 1ms !important;
-    animation-iteration-count: 1 !important;
-    transition-duration: 1ms !important;
-    scroll-behavior: auto !important;
-  }
-
-  [data-reveal],
-  [data-hero-stagger] {
-    opacity: 1;
-    transform: none;
-  }
-}
-
-/* ===== Minimal Light Theme Override ===== */
-body.theme-minimal {
-  background: #f1f3f6;
-  color: #1f2937;
-  font-family: "Poppins", "Segoe UI", sans-serif;
-  --text-main: #1f2937;
-  --text-muted: #4b5563;
-  --bg-card: #ffffff;
-  --line-soft: #d6dee8;
-  --teal: #1f72e8;
-  --cyan: #2f89ff;
-  --coral: #f97316;
-  --shadow-glow: none;
-}
-
-body.theme-minimal .ambient {
-  display: none;
-}
-
-body.theme-minimal p {
-  color: #4b5563;
-}
-
-body.theme-minimal .eyebrow {
-  text-transform: uppercase;
-  letter-spacing: 0.12em;
-  font-family: "Poppins", "Segoe UI", sans-serif;
-  font-size: 0.74rem;
-  color: #2563eb;
-}
-
-body.theme-minimal .eyebrow::before,
-body.theme-minimal .hero-copy::before,
-body.theme-minimal .hero-kicker-pill::before,
-body.theme-minimal .hero-title::before,
-body.theme-minimal .hero-title::after {
-  display: none !important;
-}
-
-body.theme-minimal h1,
-body.theme-minimal h2,
-body.theme-minimal h3,
-body.theme-minimal .brand-text,
-body.theme-minimal .metric-value,
-body.theme-minimal .benchmark-kpi {
-  font-family: "Poppins", "Segoe UI", sans-serif;
-}
-
-body.theme-minimal .site-header {
-  background: #ffffff;
-  border-bottom: 1px solid #e5e7eb;
-  padding: 0;
-}
-
-body.theme-minimal .site-header::after {
-  display: none;
-}
-
-body.theme-minimal .header-inner {
-  min-height: 78px;
-  border-radius: 0;
-  border: none;
-  background: #ffffff;
-  box-shadow: none;
-  padding: 0 0.2rem;
-}
-
-body.theme-minimal .header-inner::before {
-  display: none;
-}
-
-body.theme-minimal .brand-logo {
-  width: 40px;
-  height: 40px;
-  border-radius: 8px;
-  box-shadow: none;
-  animation: none;
-}
-
-body.theme-minimal .brand-text {
-  color: #1f3f73;
-  background: none;
-  -webkit-background-clip: initial;
-  background-clip: initial;
-  font-weight: 800;
-  letter-spacing: 0.02em;
-}
-
-body.theme-minimal .brand-sub {
-  color: #f97316;
-  font-family: "Poppins", "Segoe UI", sans-serif;
-  font-size: 0.68rem;
-  text-transform: none;
-  letter-spacing: 0;
-}
-
-body.theme-minimal .site-nav {
-  background: transparent;
-  border: none;
-  gap: 0.1rem;
-}
-
-body.theme-minimal .site-nav a {
-  color: #374151;
-  border-radius: 8px;
-  font-weight: 500;
-  font-family: "Poppins", "Segoe UI", sans-serif;
-  padding: 0.46rem 0.72rem;
-}
-
-body.theme-minimal .site-nav a:hover,
-body.theme-minimal .site-nav a:focus-visible {
-  background: #eef3fb;
-  color: #1f2937;
-}
-
-body.theme-minimal .site-nav a.active {
-  color: #1f2937;
-  background: #eef3fb;
-  box-shadow: none;
-}
-
-body.theme-minimal .header-cta {
-  min-height: 44px;
-  border-radius: 999px;
-  background: #1f72e8;
-  color: #ffffff;
-  border: 2px solid #f97316;
-  box-shadow: none;
-  padding: 0 1.2rem;
-}
-
-body.theme-minimal .header-cta:hover,
-body.theme-minimal .header-cta:focus-visible {
-  background: #155ac4;
-}
-
-body.theme-minimal .section {
-  padding: 4.4rem 0;
-}
-
-body.theme-minimal .legacy,
-body.theme-minimal .assist-loop,
-body.theme-minimal .integrations {
-  background: transparent;
-}
-
-body.theme-minimal .hero::before,
-body.theme-minimal .hero::after {
-  display: none;
-}
-
-body.theme-minimal .hero {
-  padding-top: 3rem;
-  min-height: auto;
-}
-
-body.theme-minimal .hero-grid {
-  gap: 2.4rem;
-}
-
-body.theme-minimal .hero-copy {
-  border: none;
-  background: transparent;
-  box-shadow: none;
-  padding: 0;
-}
-
-body.theme-minimal .hero-kicker-row,
-body.theme-minimal .hero-proof,
-body.theme-minimal .hero-floating {
-  display: none;
-}
-
-body.theme-minimal .hero-title {
-  color: #24282f;
-  text-shadow: none;
-  font-size: clamp(2.45rem, 5vw, 4.35rem);
-  letter-spacing: -0.02em;
-  line-height: 1.08;
-  max-width: 12ch;
-}
-
-body.theme-minimal .hero-subtitle {
-  max-width: 54ch;
-  font-size: 1.18rem;
-  color: #4b5563;
-}
-
-body.theme-minimal .hero-cta .btn-primary {
-  background: #1f72e8;
-  color: #ffffff;
-  box-shadow: none;
-}
-
-body.theme-minimal .hero-cta .btn-primary::after {
-  display: none;
-}
-
-body.theme-minimal .hero-cta .btn-outline {
-  border-color: #cbd5e1;
-  background: #ffffff;
-  color: #1f2937;
-}
-
-body.theme-minimal .hero-metrics {
-  margin-top: 1.2rem;
-}
-
-body.theme-minimal .metric-chip {
-  border: 1px solid #d9e1ea;
-  border-radius: 12px;
-  background: #ffffff;
-  box-shadow: none;
-}
-
-body.theme-minimal .metric-value {
-  color: #1f72e8;
-}
-
-body.theme-minimal .metric-label {
-  color: #4b5563;
-}
-
-body.theme-minimal .hero-visual {
-  border: 1px solid #d6dee8;
-  border-radius: 16px;
-  background: #ffffff;
-  box-shadow: none;
-}
-
-body.theme-minimal .hero-visual::before {
-  background: none;
-}
-
-body.theme-minimal #hero-wave {
-  opacity: 0.65;
-}
-
-body.theme-minimal .hero-glass {
-  background: rgba(255, 255, 255, 0.92);
-  border: 1px solid #d6dee8;
-  backdrop-filter: none;
-}
-
-body.theme-minimal .glass-label {
-  color: #1f72e8;
-}
-
-body.theme-minimal .live-feed li {
-  color: #1f2937;
-}
-
-body.theme-minimal .feed-pill {
-  border-radius: 999px;
-}
-
-body.theme-minimal .intent-hot {
-  color: #064e3b;
-  background: #d1fae5;
-}
-
-body.theme-minimal .intent-mid {
-  color: #1e3a8a;
-  background: #dbeafe;
-}
-
-body.theme-minimal .intent-save {
-  color: #9a3412;
-  background: #ffedd5;
-}
-
-body.theme-minimal .wave-divider-canvas {
-  border-radius: 16px;
-  border: 1px solid #d6dee8;
-  background: #ffffff;
-  box-shadow: none;
-  animation: none;
-}
-
-body.theme-minimal .section-head h2,
-body.theme-minimal .pain-card h3,
-body.theme-minimal .legacy-panel h3,
-body.theme-minimal .product-card h3,
-body.theme-minimal .detail-card h3,
-body.theme-minimal .assist-loop-card h3,
-body.theme-minimal .timeline-grid h3,
-body.theme-minimal .guardrail-grid h3,
-body.theme-minimal .faq-item summary,
-body.theme-minimal .spotlight-value,
-body.theme-minimal .benchmark-card h3 {
-  color: #1f2937;
-}
-
-body.theme-minimal .benchmark-kpi {
-  color: #1f72e8;
-  text-shadow: none;
-}
-
-body.theme-minimal .spotlight-label,
-body.theme-minimal .spotlight-note,
-body.theme-minimal .benchmark-card p,
-body.theme-minimal .signal-item span,
-body.theme-minimal .language-title,
-body.theme-minimal .segment-jumps p,
-body.theme-minimal .accent-row p,
-body.theme-minimal .audio-time,
-body.theme-minimal .timeline-grid p,
-body.theme-minimal .guardrail-grid p,
-body.theme-minimal .faq-item p,
-body.theme-minimal .stack-strip span,
-body.theme-minimal .cta-copy p,
-body.theme-minimal .cta-bullets li {
-  color: #4b5563;
-}
-
-body.theme-minimal .cta-bullets {
-  color: #374151;
-}
-
-body.theme-minimal .btn {
-  font-family: "Poppins", "Segoe UI", sans-serif;
-  font-weight: 600;
-}
-
-body.theme-minimal .btn:hover,
-body.theme-minimal .btn:focus-visible {
-  transform: none;
-}
-
-body.theme-minimal .pain-card,
-body.theme-minimal .legacy-panel,
-body.theme-minimal .product-card,
-body.theme-minimal .detail-card,
-body.theme-minimal .assist-loop-card,
-body.theme-minimal .audio-card,
-body.theme-minimal .benchmark-card,
-body.theme-minimal .spotlight-card,
-body.theme-minimal .timeline-grid article,
-body.theme-minimal .guardrail-grid article,
-body.theme-minimal .demo-form,
-body.theme-minimal .faq-item,
-body.theme-minimal .stack-strip span {
-  background: #ffffff;
-  border: 1px solid #dbe2eb;
-  box-shadow: none;
-}
-
-body.theme-minimal .product-card::after,
-body.theme-minimal .audio-card::before,
-body.theme-minimal #benchmarks::before {
-  display: none;
-}
-
-body.theme-minimal .product-tag,
-body.theme-minimal .benchmark-badge {
-  background: #eaf2ff;
-  color: #1f3f73;
-}
-
-body.theme-minimal .benchmark-signal {
-  background: #f3f4f6;
-  color: #4b5563;
-  border-color: #d1d5db;
-}
-
-body.theme-minimal .bar-track {
-  border-color: #d6dee8;
-  background: #eef2f7;
-}
-
-body.theme-minimal .bar-track i {
-  background: linear-gradient(90deg, #1f72e8, #3b82f6);
-}
-
-body.theme-minimal .chip,
-body.theme-minimal .segment-btn,
-body.theme-minimal .transcript-item {
-  background: #ffffff;
-  border: 1px solid #d6dee8;
-  color: #374151;
-}
-
-body.theme-minimal .segment-btn.active {
-  background: #1f72e8;
-  color: #ffffff;
-}
-
-body.theme-minimal .benchmark-card:hover,
-body.theme-minimal .benchmark-card:focus-within {
-  transform: none;
-  box-shadow: none;
-}
-
-body.theme-minimal .benchmark-card[data-priority="high"] {
-  border-color: #dbe2eb;
-  box-shadow: none;
-}
-
-body.theme-minimal .benchmark-card[data-priority="high"] .benchmark-kpi {
-  font-size: 1.9rem;
-}
-
-body.theme-minimal .demo-form label {
-  color: #334155;
-}
-
-body.theme-minimal .demo-form input,
-body.theme-minimal .demo-form select,
-body.theme-minimal .demo-form textarea {
-  background: #ffffff;
-  color: #1f2937;
-  border: 1px solid #cfd8e3;
-}
-
-body.theme-minimal .demo-form input::placeholder,
-body.theme-minimal .demo-form textarea::placeholder {
-  color: #64748b;
-  opacity: 1;
-}
-
-body.theme-minimal .demo-form input:focus-visible,
-body.theme-minimal .demo-form select:focus-visible,
-body.theme-minimal .demo-form textarea:focus-visible {
-  outline: 2px solid #93c5fd;
-  outline-offset: 1px;
-}
-
-body.theme-minimal .form-note {
-  color: #4b5563;
-}
-
-body.theme-minimal .form-note a {
-  color: #1f72e8;
-}
-
-body.theme-minimal .site-footer {
-  border-top: 1px solid #e5e7eb;
-  background: #ffffff;
-}
-
-body.theme-minimal .toast {
-  background: #ffffff;
-  color: #1f2937;
-  border-color: #d6dee8;
-}
-
-body.theme-minimal .toast.error {
-  border-color: #fca5a5;
-}
-
-@media (max-width: 940px) {
-  body.theme-minimal .header-inner {
-    min-height: 70px;
-  }
-
-  body.theme-minimal .hero-grid {
+  .product-grid,
+  .benchmark-spotlight {
     grid-template-columns: 1fr;
+  }
+
+  .benchmark-grid,
+  .guardrail-grid {
+    grid-template-columns: 1fr 1fr;
+  }
+
+  .timeline-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .timeline-grid article {
+    border-right: none;
+    border-bottom: var(--bw) solid var(--border);
+  }
+
+  .timeline-grid article:last-child {
+    border-bottom: none;
+  }
+
+  .hero-proof {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 600px) {
+  .site-nav {
+    display: none;
+  }
+
+  .pain-grid,
+  .benchmark-grid,
+  .guardrail-grid,
+  .assist-loop-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .hero-metrics {
+    flex-direction: column;
+  }
+
+  .hero-cta {
+    flex-direction: column;
+  }
+
+  .hero-cta .btn {
+    width: 100%;
+    justify-content: center;
+  }
+
+  .section {
+    padding: 60px 0;
   }
 }


### PR DESCRIPTION
## Summary
- Complete redesign of `styles.css` with a neo-brutalist palette (cream `#fffef0`, black `#0d0d0d`, yellow `#ffe500`, blue `#0055ff`, orange `#ff4500`)
- Hard 5px offset box shadows with no border-radius throughout
- Grid texture background, lift-on-hover card interactions
- Updated `script.js` canvas colors for audio visualizer (yellow/orange bars) and wave animations
- Typography: Poppins 900 weight, all-caps labels, tight letter-spacing

## Test plan
- [ ] Visual check on localhost — header, hero, cards, CTA, footer
- [ ] Audio visualizer renders in yellow/orange
- [ ] Scroll animations and legacy panel reveal work correctly
- [ ] Existing 89 Playwright unit tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)