### PR TITLE
fix: remove @import from features.css, load styles via link tags

### DIFF
--- a/features.css
+++ b/features.css
@@ -1,0 +1,888 @@
+/* ══════════════════════════════════════════════════════════════
+   VOCA AI — FEATURES PAGE STYLESHEET
+   Extends the neo-brutalist design system from styles.css
+   ══════════════════════════════════════════════════════════════ */
+
+@import url('./styles.css');
+
+/* ── SMOOTH SCROLL ───────────────────────────────────────────── */
+html {
+  scroll-behavior: smooth;
+}
+
+/* ══════════════════════════════════════════════════════════════
+   ANIMATIONS
+   ══════════════════════════════════════════════════════════════ */
+
+@keyframes fadeInUp {
+  from {
+    opacity: 0;
+    transform: translateY(28px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@keyframes fadeIn {
+  from { opacity: 0; }
+  to   { opacity: 1; }
+}
+
+@keyframes slideInLeft {
+  from {
+    opacity: 0;
+    transform: translateX(-24px);
+  }
+  to {
+    opacity: 1;
+    transform: translateX(0);
+  }
+}
+
+@keyframes pulseAccent {
+  0%, 100% { box-shadow: var(--shadow); }
+  50%       { box-shadow: var(--shadow-lg); }
+}
+
+/* Utility: apply entrance animation once element has .is-visible class
+   (toggled by IntersectionObserver in JS, or just always-on via class) */
+.anim-fade-up {
+  opacity: 0;
+  transform: translateY(28px);
+  transition: opacity 0.45s ease, transform 0.45s ease;
+}
+
+.anim-fade-up.is-visible {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+/* ══════════════════════════════════════════════════════════════
+   FEATURES SUBNAV — sticky pill nav below main header
+   ══════════════════════════════════════════════════════════════ */
+.features-subnav {
+  position: sticky;
+  top: 60px; /* sits flush below the 60px site-header */
+  z-index: 90;
+  background: var(--bg-dark);
+  border-bottom: var(--bw) solid var(--border);
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+  scrollbar-width: none;
+}
+
+.features-subnav::-webkit-scrollbar {
+  display: none;
+}
+
+.features-subnav-inner {
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+  padding: 0.55rem var(--container-pad, 4%);
+  width: var(--container);
+  margin: 0 auto;
+  min-width: max-content;
+}
+
+.features-subnav-link {
+  font-family: "Poppins", system-ui, sans-serif;
+  font-size: 0.68rem;
+  font-weight: 800;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--text-inv);
+  text-decoration: none;
+  padding: 0.3rem 0.85rem;
+  border: 2px solid transparent;
+  border-radius: 999px; /* pill */
+  white-space: nowrap;
+  transition: background 0.1s, border-color 0.1s, color 0.1s;
+}
+
+.features-subnav-link:hover {
+  background: rgba(255, 229, 0, 0.15);
+  border-color: var(--yellow);
+  color: var(--yellow);
+}
+
+.features-subnav-link.active {
+  background: var(--yellow);
+  border-color: var(--yellow);
+  color: var(--text-main);
+}
+
+/* ══════════════════════════════════════════════════════════════
+   FEATURES HERO
+   ══════════════════════════════════════════════════════════════ */
+.features-hero {
+  padding: 90px 0 70px;
+  background: var(--bg-dark);
+  color: var(--text-inv);
+  border-bottom: var(--bw) solid var(--border);
+  position: relative;
+  overflow: hidden;
+}
+
+/* Subtle grid texture on top of the dark background */
+.features-hero::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background-image:
+    repeating-linear-gradient(
+      0deg,
+      rgba(255, 229, 0, 0.04) 0,
+      rgba(255, 229, 0, 0.04) 1px,
+      transparent 1px,
+      transparent 28px
+    ),
+    repeating-linear-gradient(
+      90deg,
+      rgba(255, 229, 0, 0.04) 0,
+      rgba(255, 229, 0, 0.04) 1px,
+      transparent 1px,
+      transparent 28px
+    );
+  pointer-events: none;
+}
+
+.features-hero-inner {
+  position: relative;
+  z-index: 1;
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 3.5rem;
+  align-items: center;
+}
+
+.features-hero-copy .eyebrow {
+  background: var(--yellow);
+  color: var(--text-main);
+  border-color: var(--yellow);
+}
+
+.features-hero-title {
+  font-size: clamp(2.4rem, 5.5vw, 4.4rem);
+  font-weight: 900;
+  line-height: 1.02;
+  letter-spacing: -0.03em;
+  color: var(--text-inv);
+  margin-bottom: 1.1rem;
+}
+
+.features-hero-title em {
+  font-style: normal;
+  color: var(--yellow);
+}
+
+.features-hero-subtitle {
+  font-size: 1rem;
+  font-weight: 500;
+  color: rgba(255, 254, 240, 0.7);
+  line-height: 1.65;
+  margin-bottom: 1.75rem;
+}
+
+.features-hero-cta {
+  display: flex;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+/* Right-side stat block in hero */
+.features-hero-stats {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 0.85rem;
+}
+
+.features-stat-card {
+  padding: 1.4rem;
+  border: var(--bw) solid var(--yellow);
+  background: rgba(255, 229, 0, 0.06);
+  box-shadow: 5px 5px 0 var(--yellow);
+  animation: fadeInUp 0.55s ease both;
+}
+
+.features-stat-card:nth-child(1) { animation-delay: 0.1s; }
+.features-stat-card:nth-child(2) { animation-delay: 0.2s; }
+.features-stat-card:nth-child(3) { animation-delay: 0.3s; }
+.features-stat-card:nth-child(4) { animation-delay: 0.4s; }
+
+.features-stat-value {
+  font-size: 2rem;
+  font-weight: 900;
+  line-height: 1;
+  letter-spacing: -0.03em;
+  color: var(--yellow);
+  margin-bottom: 0.3rem;
+}
+
+.features-stat-label {
+  font-size: 0.65rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: rgba(255, 254, 240, 0.65);
+}
+
+/* ══════════════════════════════════════════════════════════════
+   ALTERNATING SECTION BACKGROUNDS
+   ══════════════════════════════════════════════════════════════ */
+.features-section {
+  padding: 80px 0;
+}
+
+.features-section--light {
+  background: var(--bg-main);
+}
+
+.features-section--white {
+  background: var(--bg-card);
+}
+
+.features-section--dark {
+  background: var(--bg-dark);
+  color: var(--text-inv);
+}
+
+.features-section--dark .section-head p:not(.eyebrow) {
+  color: rgba(255, 254, 240, 0.65);
+}
+
+.features-section--dark h2 {
+  color: var(--text-inv);
+}
+
+.features-section--dark .eyebrow {
+  background: var(--yellow);
+  color: var(--text-main);
+}
+
+/* ══════════════════════════════════════════════════════════════
+   FEATURE GRID & CARDS
+   ══════════════════════════════════════════════════════════════ */
+.feature-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 1.25rem;
+}
+
+.feature-card {
+  border: var(--bw) solid var(--border);
+  background: var(--bg-card);
+  box-shadow: var(--shadow);
+  padding: 1.75rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.85rem;
+  transition: transform 0.12s ease, box-shadow 0.12s ease;
+
+  /* stagger entrance animation */
+  animation: fadeInUp 0.5s ease both;
+}
+
+.feature-card:nth-child(1)  { animation-delay: 0.05s; }
+.feature-card:nth-child(2)  { animation-delay: 0.10s; }
+.feature-card:nth-child(3)  { animation-delay: 0.15s; }
+.feature-card:nth-child(4)  { animation-delay: 0.20s; }
+.feature-card:nth-child(5)  { animation-delay: 0.25s; }
+.feature-card:nth-child(6)  { animation-delay: 0.30s; }
+.feature-card:nth-child(7)  { animation-delay: 0.35s; }
+.feature-card:nth-child(8)  { animation-delay: 0.40s; }
+.feature-card:nth-child(9)  { animation-delay: 0.45s; }
+
+.feature-card:hover {
+  transform: translate(-3px, -3px);
+  box-shadow: var(--shadow-lg);
+}
+
+.feature-card:hover .feature-icon {
+  background: var(--text-main);
+  color: var(--yellow);
+}
+
+/* Dark-section card variant */
+.features-section--dark .feature-card {
+  background: rgba(255, 255, 255, 0.05);
+  border-color: rgba(255, 229, 0, 0.3);
+  box-shadow: 5px 5px 0 rgba(255, 229, 0, 0.25);
+  color: var(--text-inv);
+}
+
+.features-section--dark .feature-card:hover {
+  background: rgba(255, 229, 0, 0.08);
+  box-shadow: 8px 8px 0 rgba(255, 229, 0, 0.4);
+}
+
+.features-section--dark .feature-card h3 {
+  color: var(--text-inv);
+}
+
+.features-section--dark .feature-card p {
+  color: rgba(255, 254, 240, 0.65);
+}
+
+/* ── Feature Icon ────────────────────────────────────────────── */
+.feature-icon {
+  width: 48px;
+  height: 48px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--yellow);
+  border: var(--bw) solid var(--border);
+  flex-shrink: 0;
+  font-size: 1.35rem;
+  line-height: 1;
+  transition: background 0.12s ease, color 0.12s ease;
+}
+
+.feature-icon svg,
+.feature-icon img {
+  width: 24px;
+  height: 24px;
+  display: block;
+}
+
+.feature-card h3 {
+  font-size: 0.88rem;
+  font-weight: 900;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  margin: 0;
+  padding-bottom: 0.5rem;
+  border-bottom: 3px solid var(--yellow);
+}
+
+.feature-card p {
+  font-size: 0.82rem;
+  color: var(--text-muted);
+  line-height: 1.6;
+  margin: 0;
+  flex: 1;
+}
+
+.feature-card-tag {
+  font-size: 0.6rem;
+  font-weight: 800;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  padding: 0.18rem 0.5rem;
+  border: 2px solid var(--border);
+  background: var(--blue);
+  color: #fff;
+  display: inline-block;
+  align-self: flex-start;
+}
+
+/* ── Featured (large / wide) card variant ───────────────────── */
+.feature-card--featured {
+  grid-column: span 2;
+  flex-direction: row;
+  align-items: flex-start;
+  gap: 1.5rem;
+}
+
+.feature-card--featured .feature-icon {
+  width: 64px;
+  height: 64px;
+  font-size: 1.75rem;
+  flex-shrink: 0;
+}
+
+.feature-card--featured h3 {
+  font-size: 1rem;
+}
+
+/* ══════════════════════════════════════════════════════════════
+   INTEGRATION LOGOS GRID
+   ══════════════════════════════════════════════════════════════ */
+.integration-grid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  justify-content: center;
+  margin-top: 2.5rem;
+}
+
+.integration-tile {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.55rem;
+  padding: 0.65rem 1.25rem;
+  border: var(--bw) solid var(--border);
+  background: var(--bg-card);
+  box-shadow: 4px 4px 0 var(--border);
+  font-size: 0.72rem;
+  font-weight: 800;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: var(--text-main);
+  cursor: default;
+  transition: transform 0.1s ease, box-shadow 0.1s ease, background 0.1s ease;
+  animation: fadeInUp 0.45s ease both;
+}
+
+.integration-tile:nth-child(1)  { animation-delay: 0.05s; }
+.integration-tile:nth-child(2)  { animation-delay: 0.10s; }
+.integration-tile:nth-child(3)  { animation-delay: 0.15s; }
+.integration-tile:nth-child(4)  { animation-delay: 0.20s; }
+.integration-tile:nth-child(5)  { animation-delay: 0.25s; }
+.integration-tile:nth-child(6)  { animation-delay: 0.30s; }
+.integration-tile:nth-child(7)  { animation-delay: 0.35s; }
+.integration-tile:nth-child(8)  { animation-delay: 0.40s; }
+
+.integration-tile:hover {
+  transform: translate(-2px, -2px);
+  box-shadow: 6px 6px 0 var(--border);
+  background: var(--yellow);
+}
+
+.integration-tile-logo {
+  width: 20px;
+  height: 20px;
+  object-fit: contain;
+  display: block;
+  flex-shrink: 0;
+}
+
+/* Category label above integration grid */
+.integration-category {
+  font-size: 0.65rem;
+  font-weight: 800;
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+  color: var(--text-muted);
+  margin-bottom: 0.75rem;
+  padding-bottom: 0.4rem;
+  border-bottom: 2px solid var(--border);
+}
+
+/* ══════════════════════════════════════════════════════════════
+   COMPLIANCE BADGES
+   ══════════════════════════════════════════════════════════════ */
+.compliance-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.65rem;
+  margin-top: 1.25rem;
+}
+
+.compliance-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  font-size: 0.68rem;
+  font-weight: 800;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  padding: 0.35rem 0.85rem 0.35rem 0.6rem;
+  border: var(--bw) solid var(--border);
+  border-radius: 999px; /* pill */
+  background: var(--bg-card);
+  color: var(--text-main);
+  box-shadow: 3px 3px 0 var(--border);
+  transition: transform 0.08s, box-shadow 0.08s, background 0.08s;
+}
+
+.compliance-badge:hover {
+  transform: translate(-1px, -1px);
+  box-shadow: 4px 4px 0 var(--border);
+  background: var(--green);
+}
+
+/* Checkmark icon inside badge */
+.compliance-badge::before {
+  content: "";
+  display: inline-block;
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  background: var(--green);
+  border: 2px solid var(--border);
+  flex-shrink: 0;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 12 12'%3E%3Cpolyline points='2,6 5,9 10,3' fill='none' stroke='%230d0d0d' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: center;
+  background-size: 10px 10px;
+}
+
+.compliance-badge:hover::before {
+  background-color: var(--text-main);
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 12 12'%3E%3Cpolyline points='2,6 5,9 10,3' fill='none' stroke='%23ffe500' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E");
+}
+
+/* ══════════════════════════════════════════════════════════════
+   DEEP-DIVE / DETAIL ROWS (alternating text + visual layout)
+   ══════════════════════════════════════════════════════════════ */
+.feature-detail-row {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 3rem;
+  align-items: start;
+  padding: 80px 0;
+  border-bottom: var(--bw) solid var(--border);
+}
+
+.feature-detail-row:last-child {
+  border-bottom: none;
+}
+
+/* Flip: odd rows have visual on the right (default), even rows flip */
+.feature-detail-row--flip {
+  direction: rtl;
+}
+
+.feature-detail-row--flip > * {
+  direction: ltr;
+}
+
+.feature-detail-copy p {
+  font-size: 0.875rem;
+  color: var(--text-muted);
+  line-height: 1.65;
+  margin-bottom: 1.1rem;
+}
+
+.feature-detail-visual {
+  border: var(--bw) solid var(--border);
+  background: var(--bg-card);
+  box-shadow: var(--shadow-lg);
+  overflow: hidden;
+}
+
+/* ══════════════════════════════════════════════════════════════
+   FEATURE HIGHLIGHT BAND (full-width accent stripe)
+   ══════════════════════════════════════════════════════════════ */
+.features-band {
+  background: var(--yellow);
+  border-top: var(--bw) solid var(--border);
+  border-bottom: var(--bw) solid var(--border);
+  padding: 2.5rem 0;
+}
+
+.features-band-inner {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 2rem;
+  flex-wrap: wrap;
+}
+
+.features-band h2 {
+  font-size: clamp(1.4rem, 3vw, 2rem);
+  margin: 0;
+}
+
+/* ══════════════════════════════════════════════════════════════
+   FEATURE COMPARISON TABLE
+   ══════════════════════════════════════════════════════════════ */
+.feature-compare-table {
+  width: 100%;
+  border-collapse: collapse;
+  border: var(--bw) solid var(--border);
+  box-shadow: var(--shadow-lg);
+  font-size: 0.82rem;
+}
+
+.feature-compare-table th {
+  background: var(--text-main);
+  color: var(--yellow);
+  font-size: 0.72rem;
+  font-weight: 900;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  padding: 0.85rem 1rem;
+  text-align: left;
+  border: var(--bw) solid var(--border);
+}
+
+.feature-compare-table th:first-child {
+  background: var(--bg-main);
+  color: var(--text-main);
+}
+
+.feature-compare-table td {
+  padding: 0.75rem 1rem;
+  border: var(--bw) solid var(--border);
+  font-weight: 500;
+  vertical-align: middle;
+  background: var(--bg-card);
+  transition: background 0.08s;
+}
+
+.feature-compare-table tr:hover td {
+  background: var(--yellow);
+}
+
+.feature-compare-table td:first-child {
+  font-weight: 800;
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  background: var(--bg-main);
+}
+
+.feature-compare-table tr:hover td:first-child {
+  background: var(--yellow);
+}
+
+.compare-check {
+  color: var(--green);
+  font-weight: 900;
+  font-size: 1rem;
+}
+
+.compare-cross {
+  color: var(--orange);
+  font-weight: 900;
+  font-size: 1rem;
+}
+
+/* ══════════════════════════════════════════════════════════════
+   STEP / PROCESS LIST
+   ══════════════════════════════════════════════════════════════ */
+.feature-steps {
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+  border: var(--bw) solid var(--border);
+  box-shadow: var(--shadow-lg);
+  counter-reset: fstep;
+}
+
+.feature-step {
+  display: grid;
+  grid-template-columns: 3.5rem 1fr;
+  border-bottom: var(--bw) solid var(--border);
+  background: var(--bg-card);
+  counter-increment: fstep;
+  transition: background 0.1s;
+  animation: fadeInUp 0.45s ease both;
+}
+
+.feature-step:nth-child(1) { animation-delay: 0.05s; }
+.feature-step:nth-child(2) { animation-delay: 0.12s; }
+.feature-step:nth-child(3) { animation-delay: 0.19s; }
+.feature-step:nth-child(4) { animation-delay: 0.26s; }
+.feature-step:nth-child(5) { animation-delay: 0.33s; }
+
+.feature-step:last-child {
+  border-bottom: none;
+}
+
+.feature-step:hover {
+  background: var(--yellow);
+}
+
+.feature-step-num {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--text-main);
+  color: var(--yellow);
+  font-size: 0.85rem;
+  font-weight: 900;
+  border-right: var(--bw) solid var(--border);
+  flex-shrink: 0;
+  padding: 1.1rem 0;
+}
+
+.feature-step-num::after {
+  content: counter(fstep, decimal-leading-zero);
+}
+
+.feature-step-body {
+  padding: 1.1rem 1.25rem;
+}
+
+.feature-step-body h4 {
+  font-size: 0.82rem;
+  font-weight: 900;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin: 0 0 0.3rem;
+}
+
+.feature-step-body p {
+  font-size: 0.78rem;
+  color: var(--text-muted);
+  margin: 0;
+  line-height: 1.5;
+}
+
+.feature-step:hover .feature-step-body p {
+  color: var(--text-main);
+}
+
+/* ══════════════════════════════════════════════════════════════
+   MINI METRIC CHIPS (reusable inside feature cards / sections)
+   ══════════════════════════════════════════════════════════════ */
+.feature-chip-row {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+  margin-top: 0.5rem;
+}
+
+.feature-chip {
+  font-size: 0.65rem;
+  font-weight: 800;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  padding: 0.22rem 0.55rem;
+  border: 2px solid var(--border);
+  background: var(--bg-main);
+  color: var(--text-main);
+  transition: background 0.08s;
+}
+
+.feature-chip:hover {
+  background: var(--yellow);
+}
+
+.feature-chip--accent {
+  background: var(--yellow);
+}
+
+.feature-chip--blue {
+  background: var(--blue);
+  color: #fff;
+  border-color: var(--blue);
+}
+
+.feature-chip--green {
+  background: var(--green);
+  border-color: var(--border);
+}
+
+/* ══════════════════════════════════════════════════════════════
+   RESPONSIVE BREAKPOINTS
+   ══════════════════════════════════════════════════════════════ */
+
+/* ── Tablet: 1024px ────────────────────────────────────────── */
+@media (max-width: 1024px) {
+  .feature-grid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+
+  .feature-card--featured {
+    grid-column: span 2;
+  }
+
+  .features-hero-inner {
+    grid-template-columns: 1fr;
+    gap: 2.5rem;
+  }
+
+  .features-hero-stats {
+    grid-template-columns: repeat(4, 1fr);
+  }
+
+  .feature-detail-row {
+    gap: 2rem;
+  }
+}
+
+/* ── Mobile: 768px ─────────────────────────────────────────── */
+@media (max-width: 768px) {
+  .features-hero {
+    padding: 70px 0 50px;
+  }
+
+  .features-hero-title {
+    font-size: clamp(2rem, 8vw, 2.8rem);
+  }
+
+  .features-hero-stats {
+    grid-template-columns: repeat(2, 1fr);
+  }
+
+  .feature-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .feature-card--featured {
+    grid-column: span 1;
+    flex-direction: column;
+  }
+
+  .feature-detail-row {
+    grid-template-columns: 1fr;
+    padding: 50px 0;
+  }
+
+  .feature-detail-row--flip {
+    direction: ltr;
+  }
+
+  .integration-grid {
+    gap: 0.5rem;
+  }
+
+  .integration-tile {
+    padding: 0.55rem 0.9rem;
+    font-size: 0.68rem;
+  }
+
+  .features-band-inner {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 1.25rem;
+  }
+
+  .features-subnav-inner {
+    padding: 0.55rem 1rem;
+  }
+
+  .feature-compare-table {
+    font-size: 0.75rem;
+  }
+
+  .feature-compare-table th,
+  .feature-compare-table td {
+    padding: 0.6rem 0.65rem;
+  }
+
+  .features-section {
+    padding: 60px 0;
+  }
+}
+
+/* ── Small mobile: 480px ───────────────────────────────────── */
+@media (max-width: 480px) {
+  .features-hero-cta {
+    flex-direction: column;
+  }
+
+  .features-hero-cta .btn {
+    width: 100%;
+    justify-content: center;
+  }
+
+  .features-hero-stats {
+    grid-template-columns: 1fr 1fr;
+  }
+
+  .compliance-list {
+    gap: 0.4rem;
+  }
+
+  .compliance-badge {
+    font-size: 0.62rem;
+    padding: 0.3rem 0.7rem 0.3rem 0.5rem;
+  }
+
+  .feature-steps {
+    box-shadow: none;
+  }
+
+  .feature-step-num {
+    font-size: 0.75rem;
+  }
+}

--- a/features.css
+++ b/features.css
@@ -3,8 +3,6 @@
    Extends the neo-brutalist design system from styles.css
    ══════════════════════════════════════════════════════════════ */
 
-@import url('./styles.css');
-
 /* ── SMOOTH SCROLL ───────────────────────────────────────────── */
 html {
   scroll-behavior: smooth;

--- a/features.html
+++ b/features.html
@@ -1,0 +1,663 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>VOCA AI | Features — Every Capability in One Revenue Engine</title>
+    <meta
+      name="description"
+      content="Explore the full VOCA AI feature set: real-time intelligence, autonomous voice, analytics, integrations, and enterprise compliance."
+    />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;500;600;700;800&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="styles.css" />
+    <link rel="stylesheet" href="features.css" />
+  </head>
+  <body class="theme-minimal">
+    <div class="ambient ambient-a"></div>
+    <div class="ambient ambient-b"></div>
+    <div class="ambient ambient-c"></div>
+
+    <header class="site-header" id="top">
+      <div class="container header-inner">
+        <a class="brand" href="index.html" aria-label="VOCA AI Home">
+          <img class="brand-logo" src="assets/voca-logo.svg" alt="" aria-hidden="true" />
+          <span class="brand-lockup">
+            <span class="brand-text">VOCA AI</span>
+            <span class="brand-sub">Revenue Voice OS</span>
+          </span>
+        </a>
+        <nav class="site-nav" aria-label="Primary Navigation">
+          <a href="#realtime-intelligence">Real-Time AI</a>
+          <a href="#voice-autonomy">Voice Autonomy</a>
+          <a href="#analytics-coaching">Analytics</a>
+          <a href="#integrations">Integrations</a>
+          <a href="#compliance">Compliance</a>
+          <a href="index.html#cta">Book Demo</a>
+        </nav>
+        <a class="btn btn-small header-cta" href="index.html#cta">Talk to Sales</a>
+      </div>
+    </header>
+
+    <main>
+
+      <!-- ===================== HERO ===================== -->
+      <section class="section features-hero" id="features-hero">
+        <div class="container features-hero-inner">
+          <p class="eyebrow">The Complete Feature Stack</p>
+          <h1 class="features-hero-title">Every Feature. One Revenue Engine.</h1>
+          <p class="features-hero-subtitle">
+            AssistIQ and VoiceOS ship with everything your revenue team needs — from
+            live intent scoring and autonomous multilingual voice to enterprise-grade
+            compliance and plug-and-play CRM integrations.
+          </p>
+          <div class="features-hero-cta">
+            <a class="btn btn-primary" href="index.html#cta">Book a Demo</a>
+            <a class="btn btn-outline" href="#realtime-intelligence">Explore Features</a>
+          </div>
+          <nav class="features-anchor-nav" aria-label="Feature section anchors">
+            <a href="#realtime-intelligence">Real-Time Intelligence</a>
+            <a href="#voice-autonomy">Voice Autonomy</a>
+            <a href="#analytics-coaching">Analytics &amp; Coaching</a>
+            <a href="#integrations">Integrations</a>
+            <a href="#compliance">Compliance &amp; Security</a>
+          </nav>
+        </div>
+      </section>
+
+      <!-- ===================== REAL-TIME INTELLIGENCE ===================== -->
+      <section class="section features-section" id="realtime-intelligence">
+        <div class="container">
+          <div class="section-head" data-reveal>
+            <p class="eyebrow">VOCA AssistIQ</p>
+            <h2>Real-Time Intelligence</h2>
+            <p>
+              AssistIQ listens to every live call and delivers contextual nudges the moment they
+              matter — not after the conversation is over.
+            </p>
+          </div>
+          <div class="feature-grid" data-reveal>
+
+            <article class="feature-card" id="feat-intent-scoring">
+              <div class="feature-icon" aria-hidden="true">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" xmlns="http://www.w3.org/2000/svg">
+                  <circle cx="12" cy="12" r="10"/>
+                  <polyline points="12 6 12 12 16 14"/>
+                </svg>
+              </div>
+              <h3 class="feature-title">Live Intent Scoring</h3>
+              <p class="feature-desc">
+                Every utterance is scored for purchase intent, upsell readiness, and churn risk
+                in real time, giving agents a live signal map of where the conversation stands.
+              </p>
+            </article>
+
+            <article class="feature-card" id="feat-objection-detection">
+              <div class="feature-icon" aria-hidden="true">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" xmlns="http://www.w3.org/2000/svg">
+                  <path d="M10.29 3.86L1.82 18a2 2 0 001.71 3h16.94a2 2 0 001.71-3L13.71 3.86a2 2 0 00-3.42 0z"/>
+                  <line x1="12" y1="9" x2="12" y2="13"/>
+                  <line x1="12" y1="17" x2="12.01" y2="17"/>
+                </svg>
+              </div>
+              <h3 class="feature-title">Objection Detection</h3>
+              <p class="feature-desc">
+                Common objection patterns are identified the moment they surface. Agents receive
+                real-time response prompts drawn from top-performer playbooks.
+              </p>
+            </article>
+
+            <article class="feature-card" id="feat-nba-nudges">
+              <div class="feature-icon" aria-hidden="true">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" xmlns="http://www.w3.org/2000/svg">
+                  <polygon points="13 2 3 14 12 14 11 22 21 10 12 10 13 2"/>
+                </svg>
+              </div>
+              <h3 class="feature-title">Next-Best-Action Nudges</h3>
+              <p class="feature-desc">
+                Context-aware suggestions for upsell, cross-sell, offer framing, and escalation
+                delivered directly to the agent's screen without interrupting the call.
+              </p>
+            </article>
+
+            <article class="feature-card" id="feat-sentiment-analysis">
+              <div class="feature-icon" aria-hidden="true">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" xmlns="http://www.w3.org/2000/svg">
+                  <circle cx="12" cy="12" r="10"/>
+                  <path d="M8 14s1.5 2 4 2 4-2 4-2"/>
+                  <line x1="9" y1="9" x2="9.01" y2="9"/>
+                  <line x1="15" y1="9" x2="15.01" y2="9"/>
+                </svg>
+              </div>
+              <h3 class="feature-title">Sentiment Analysis</h3>
+              <p class="feature-desc">
+                Continuous tone and sentiment tracking surfaces frustration, hesitation, and
+                enthusiasm in real time so agents can modulate and managers can intervene.
+              </p>
+            </article>
+
+            <article class="feature-card" id="feat-near-miss-recovery">
+              <div class="feature-icon" aria-hidden="true">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" xmlns="http://www.w3.org/2000/svg">
+                  <path d="M22 11.08V12a10 10 0 11-5.93-9.14"/>
+                  <polyline points="22 4 12 14.01 9 11.01"/>
+                </svg>
+              </div>
+              <h3 class="feature-title">Near-Miss Recovery</h3>
+              <p class="feature-desc">
+                When a high-intent call drops without conversion, AssistIQ automatically
+                triggers prioritised callback queues, SMS follow-ups, and email reachout flows.
+              </p>
+            </article>
+
+            <article class="feature-card" id="feat-silence-detection">
+              <div class="feature-icon" aria-hidden="true">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" xmlns="http://www.w3.org/2000/svg">
+                  <line x1="1" y1="1" x2="23" y2="23"/>
+                  <path d="M9 9v3a3 3 0 005.12 2.12M15 9.34V4a3 3 0 00-5.94-.6"/>
+                  <path d="M17 16.95A7 7 0 015 12v-2m14 0v2a7 7 0 01-.11 1.23"/>
+                  <line x1="12" y1="19" x2="12" y2="23"/>
+                  <line x1="8" y1="23" x2="16" y2="23"/>
+                </svg>
+              </div>
+              <h3 class="feature-title">Dead-Air &amp; Silence Detection</h3>
+              <p class="feature-desc">
+                Prolonged silences trigger instant coaching prompts to help agents re-engage
+                prospects and avoid call drops due to awkward pauses.
+              </p>
+            </article>
+
+          </div>
+        </div>
+      </section>
+
+      <!-- ===================== VOICE AUTONOMY ===================== -->
+      <section class="section features-section features-section--alt" id="voice-autonomy">
+        <div class="container">
+          <div class="section-head" data-reveal>
+            <p class="eyebrow">VOCA VoiceOS</p>
+            <h2>Voice Autonomy</h2>
+            <p>
+              VoiceOS is a production-grade autonomous voice stack that handles full
+              inbound and outbound conversations across 23 Indic languages and English.
+            </p>
+          </div>
+          <div class="feature-grid" data-reveal>
+
+            <article class="feature-card" id="feat-multilingual-ivr">
+              <div class="feature-icon" aria-hidden="true">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" xmlns="http://www.w3.org/2000/svg">
+                  <circle cx="12" cy="12" r="10"/>
+                  <line x1="2" y1="12" x2="22" y2="12"/>
+                  <path d="M12 2a15.3 15.3 0 014 10 15.3 15.3 0 01-4 10 15.3 15.3 0 01-4-10 15.3 15.3 0 014-10z"/>
+                </svg>
+              </div>
+              <h3 class="feature-title">Multilingual IVR</h3>
+              <p class="feature-desc">
+                Replace rigid DTMF trees with natural-language IVR that understands and
+                responds across Hindi, Tamil, Telugu, Kannada, Bengali, Marathi, and 17 more
+                Indic languages plus English.
+              </p>
+            </article>
+
+            <article class="feature-card" id="feat-voice-synthesis">
+              <div class="feature-icon" aria-hidden="true">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" xmlns="http://www.w3.org/2000/svg">
+                  <path d="M12 1a3 3 0 00-3 3v8a3 3 0 006 0V4a3 3 0 00-3-3z"/>
+                  <path d="M19 10v2a7 7 0 01-14 0v-2"/>
+                  <line x1="12" y1="19" x2="12" y2="23"/>
+                  <line x1="8" y1="23" x2="16" y2="23"/>
+                </svg>
+              </div>
+              <h3 class="feature-title">Human-Like Voice Synthesis</h3>
+              <p class="feature-desc">
+                Low-latency neural TTS produces natural prosody, appropriate pausing, and
+                human-style turn-taking so callers cannot distinguish the AI from a live agent.
+              </p>
+            </article>
+
+            <article class="feature-card" id="feat-accent-coverage">
+              <div class="feature-icon" aria-hidden="true">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" xmlns="http://www.w3.org/2000/svg">
+                  <polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2"/>
+                </svg>
+              </div>
+              <h3 class="feature-title">Accent Coverage</h3>
+              <p class="feature-desc">
+                ASR models fine-tuned on regional accent variations ensure accurate speech
+                recognition regardless of dialect, code-switching, or mixed-language utterances.
+              </p>
+            </article>
+
+            <article class="feature-card" id="feat-call-routing">
+              <div class="feature-icon" aria-hidden="true">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" xmlns="http://www.w3.org/2000/svg">
+                  <polyline points="22 12 18 12 15 21 9 3 6 12 2 12"/>
+                </svg>
+              </div>
+              <h3 class="feature-title">Intelligent Call Routing</h3>
+              <p class="feature-desc">
+                Intent and language signals dynamically route calls to the right queue, agent
+                skill-set, or VoiceOS flow — eliminating manual dispatch and misrouting delays.
+              </p>
+            </article>
+
+            <article class="feature-card" id="feat-human-handoff">
+              <div class="feature-icon" aria-hidden="true">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" xmlns="http://www.w3.org/2000/svg">
+                  <path d="M17 21v-2a4 4 0 00-4-4H5a4 4 0 00-4 4v2"/>
+                  <circle cx="9" cy="7" r="4"/>
+                  <path d="M23 21v-2a4 4 0 00-3-3.87"/>
+                  <path d="M16 3.13a4 4 0 010 7.75"/>
+                </svg>
+              </div>
+              <h3 class="feature-title">Controlled Human Handoff</h3>
+              <p class="feature-desc">
+                Confidence-gated escalation hands complex or high-value interactions to live
+                agents with full context transfer — no caller repetition, no context loss.
+              </p>
+            </article>
+
+            <article class="feature-card" id="feat-inbound-outbound">
+              <div class="feature-icon" aria-hidden="true">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" xmlns="http://www.w3.org/2000/svg">
+                  <line x1="7" y1="17" x2="17" y2="7"/>
+                  <polyline points="7 7 17 7 17 17"/>
+                </svg>
+              </div>
+              <h3 class="feature-title">Inbound &amp; Outbound Flows</h3>
+              <p class="feature-desc">
+                VoiceOS manages both inbound resolution and outbound dialer campaigns — from
+                collections and renewals to lead qualification and appointment setting.
+              </p>
+            </article>
+
+          </div>
+        </div>
+      </section>
+
+      <!-- ===================== ANALYTICS & COACHING ===================== -->
+      <section class="section features-section" id="analytics-coaching">
+        <div class="container">
+          <div class="section-head" data-reveal>
+            <p class="eyebrow">Performance Intelligence</p>
+            <h2>Analytics &amp; Coaching</h2>
+            <p>
+              Close the loop from every call into structured coaching data. VOCA turns
+              conversation outcomes into rep growth, team trends, and manager-ready insights.
+            </p>
+          </div>
+          <div class="feature-grid" data-reveal>
+
+            <article class="feature-card" id="feat-post-call-summaries">
+              <div class="feature-icon" aria-hidden="true">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" xmlns="http://www.w3.org/2000/svg">
+                  <path d="M14 2H6a2 2 0 00-2 2v16a2 2 0 002 2h12a2 2 0 002-2V8z"/>
+                  <polyline points="14 2 14 8 20 8"/>
+                  <line x1="16" y1="13" x2="8" y2="13"/>
+                  <line x1="16" y1="17" x2="8" y2="17"/>
+                  <polyline points="10 9 9 9 8 9"/>
+                </svg>
+              </div>
+              <h3 class="feature-title">Post-Call Summaries</h3>
+              <p class="feature-desc">
+                Auto-generated structured summaries capture intent signals, objections raised,
+                outcomes, and suggested follow-up actions — pushed directly to your CRM.
+              </p>
+            </article>
+
+            <article class="feature-card" id="feat-rep-scorecards">
+              <div class="feature-icon" aria-hidden="true">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" xmlns="http://www.w3.org/2000/svg">
+                  <rect x="2" y="3" width="20" height="14" rx="2" ry="2"/>
+                  <line x1="8" y1="21" x2="16" y2="21"/>
+                  <line x1="12" y1="17" x2="12" y2="21"/>
+                </svg>
+              </div>
+              <h3 class="feature-title">Rep Scorecards</h3>
+              <p class="feature-desc">
+                Individual performance profiles track nudge acceptance rate, objection handling
+                score, conversion by call type, and talk-to-listen ratio over time.
+              </p>
+            </article>
+
+            <article class="feature-card" id="feat-trend-dashboards">
+              <div class="feature-icon" aria-hidden="true">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" xmlns="http://www.w3.org/2000/svg">
+                  <line x1="18" y1="20" x2="18" y2="10"/>
+                  <line x1="12" y1="20" x2="12" y2="4"/>
+                  <line x1="6" y1="20" x2="6" y2="14"/>
+                </svg>
+              </div>
+              <h3 class="feature-title">Trend Dashboards</h3>
+              <p class="feature-desc">
+                Real-time and historical dashboards surface conversion trends, objection
+                frequency by product, language breakdown, and queue-level performance.
+              </p>
+            </article>
+
+            <article class="feature-card" id="feat-manager-alerts">
+              <div class="feature-icon" aria-hidden="true">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" xmlns="http://www.w3.org/2000/svg">
+                  <path d="M18 8A6 6 0 006 8c0 7-3 9-3 9h18s-3-2-3-9"/>
+                  <path d="M13.73 21a2 2 0 01-3.46 0"/>
+                </svg>
+              </div>
+              <h3 class="feature-title">Manager Alerts</h3>
+              <p class="feature-desc">
+                Live alerts notify team leads when a call is at risk, when a rep ignores
+                repeated nudges, or when a high-value prospect goes cold after a missed drop.
+              </p>
+            </article>
+
+            <article class="feature-card" id="feat-coaching-loops">
+              <div class="feature-icon" aria-hidden="true">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" xmlns="http://www.w3.org/2000/svg">
+                  <polyline points="23 4 23 10 17 10"/>
+                  <polyline points="1 20 1 14 7 14"/>
+                  <path d="M3.51 9a9 9 0 0114.85-3.36L23 10M1 14l4.64 4.36A9 9 0 0020.49 15"/>
+                </svg>
+              </div>
+              <h3 class="feature-title">Automated Coaching Loops</h3>
+              <p class="feature-desc">
+                Call outcomes feed back into rep coaching plans automatically. Best-performer
+                behavior is captured and distributed across the team at scale.
+              </p>
+            </article>
+
+            <article class="feature-card" id="feat-call-transcripts">
+              <div class="feature-icon" aria-hidden="true">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" xmlns="http://www.w3.org/2000/svg">
+                  <line x1="21" y1="10" x2="7" y2="10"/>
+                  <line x1="21" y1="6" x2="3" y2="6"/>
+                  <line x1="21" y1="14" x2="3" y2="14"/>
+                  <line x1="21" y1="18" x2="7" y2="18"/>
+                </svg>
+              </div>
+              <h3 class="feature-title">Searchable Call Transcripts</h3>
+              <p class="feature-desc">
+                Every call is transcribed, tagged by topic, and indexed for full-text search —
+                enabling QA teams to surface specific moments in seconds.
+              </p>
+            </article>
+
+          </div>
+        </div>
+      </section>
+
+      <!-- ===================== INTEGRATIONS ===================== -->
+      <section class="section features-section features-section--alt" id="integrations">
+        <div class="container">
+          <div class="section-head" data-reveal>
+            <p class="eyebrow">Plug-and-Play Connectivity</p>
+            <h2>Integrations</h2>
+            <p>
+              VOCA plugs into the tools your revenue team already uses — no rip-and-replace
+              required. Native connectors keep data flowing in both directions.
+            </p>
+          </div>
+
+          <div class="integration-categories" data-reveal>
+
+            <div class="integration-category" id="integ-crm">
+              <h3 class="integration-category-title">CRM</h3>
+              <p class="integration-category-desc">
+                Bi-directional sync pushes post-call summaries, intent scores, and follow-up
+                tasks into your existing CRM workflow automatically after every call.
+              </p>
+              <ul class="integration-list">
+                <li class="integration-item">
+                  <span class="integration-name">Salesforce</span>
+                  <span class="integration-detail">Opportunity updates, task creation, custom field mapping</span>
+                </li>
+                <li class="integration-item">
+                  <span class="integration-name">HubSpot</span>
+                  <span class="integration-detail">Contact activity timeline, deal stage progression</span>
+                </li>
+                <li class="integration-item">
+                  <span class="integration-name">Zoho CRM</span>
+                  <span class="integration-detail">Lead scoring sync, call log enrichment</span>
+                </li>
+                <li class="integration-item">
+                  <span class="integration-name">Leadsquared</span>
+                  <span class="integration-detail">Pipeline updates, disposition capture</span>
+                </li>
+              </ul>
+            </div>
+
+            <div class="integration-category" id="integ-telephony">
+              <h3 class="integration-category-title">Telephony &amp; Dialer</h3>
+              <p class="integration-category-desc">
+                Connect to your existing telephony stack via certified integrations — no change
+                to your dialer configuration or call recording workflow.
+              </p>
+              <ul class="integration-list">
+                <li class="integration-item">
+                  <span class="integration-name">Exotel</span>
+                  <span class="integration-detail">Real-time audio stream, call event webhooks</span>
+                </li>
+                <li class="integration-item">
+                  <span class="integration-name">Twilio</span>
+                  <span class="integration-detail">MediaStream API, Flex integration</span>
+                </li>
+                <li class="integration-item">
+                  <span class="integration-name">NICE CXone</span>
+                  <span class="integration-detail">ACD integration, agent workspace embed</span>
+                </li>
+                <li class="integration-item">
+                  <span class="integration-name">Genesys</span>
+                  <span class="integration-detail">AudioHook, cloud telephony connectors</span>
+                </li>
+              </ul>
+            </div>
+
+            <div class="integration-category" id="integ-helpdesk">
+              <h3 class="integration-category-title">Helpdesk &amp; Support</h3>
+              <p class="integration-category-desc">
+                Route post-call actions and escalations directly into your support ticketing
+                platform to keep voice and digital service channels aligned.
+              </p>
+              <ul class="integration-list">
+                <li class="integration-item">
+                  <span class="integration-name">Zendesk</span>
+                  <span class="integration-detail">Ticket auto-creation, CSAT alignment</span>
+                </li>
+                <li class="integration-item">
+                  <span class="integration-name">Freshdesk</span>
+                  <span class="integration-detail">Conversation linking, agent notes sync</span>
+                </li>
+                <li class="integration-item">
+                  <span class="integration-name">Intercom</span>
+                  <span class="integration-detail">User event tagging from call outcomes</span>
+                </li>
+              </ul>
+            </div>
+
+            <div class="integration-category" id="integ-bi">
+              <h3 class="integration-category-title">Analytics &amp; BI</h3>
+              <p class="integration-category-desc">
+                Push conversation intelligence into your existing BI stack for cross-channel
+                revenue analysis and executive reporting.
+              </p>
+              <ul class="integration-list">
+                <li class="integration-item">
+                  <span class="integration-name">Tableau</span>
+                  <span class="integration-detail">Pre-built voice analytics connector</span>
+                </li>
+                <li class="integration-item">
+                  <span class="integration-name">Looker / BigQuery</span>
+                  <span class="integration-detail">Event stream export, custom dimensions</span>
+                </li>
+                <li class="integration-item">
+                  <span class="integration-name">Webhook API</span>
+                  <span class="integration-detail">Real-time event push to any downstream system</span>
+                </li>
+              </ul>
+            </div>
+
+          </div>
+        </div>
+      </section>
+
+      <!-- ===================== COMPLIANCE & SECURITY ===================== -->
+      <section class="section features-section" id="compliance">
+        <div class="container">
+          <div class="section-head" data-reveal>
+            <p class="eyebrow">Enterprise Trust</p>
+            <h2>Compliance &amp; Security</h2>
+            <p>
+              VOCA is built for regulated industries. Every deployment ships with the
+              controls, consent mechanisms, and audit infrastructure enterprise teams require.
+            </p>
+          </div>
+          <div class="feature-grid" data-reveal>
+
+            <article class="feature-card feature-card--compliance" id="feat-pci-dss">
+              <div class="feature-icon" aria-hidden="true">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" xmlns="http://www.w3.org/2000/svg">
+                  <rect x="1" y="4" width="22" height="16" rx="2" ry="2"/>
+                  <line x1="1" y1="10" x2="23" y2="10"/>
+                </svg>
+              </div>
+              <h3 class="feature-title">PCI-DSS Ready</h3>
+              <p class="feature-desc">
+                Payment card data is masked and redacted from call recordings and transcripts.
+                DTMF capture for card entry never traverses VOCA systems in clear text.
+              </p>
+            </article>
+
+            <article class="feature-card feature-card--compliance" id="feat-gdpr">
+              <div class="feature-icon" aria-hidden="true">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" xmlns="http://www.w3.org/2000/svg">
+                  <path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/>
+                </svg>
+              </div>
+              <h3 class="feature-title">GDPR-Ready</h3>
+              <p class="feature-desc">
+                Data residency controls, right-to-erasure workflows, and configurable
+                retention policies support GDPR and DPDP Act compliance requirements.
+              </p>
+            </article>
+
+            <article class="feature-card feature-card--compliance" id="feat-call-consent">
+              <div class="feature-icon" aria-hidden="true">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" xmlns="http://www.w3.org/2000/svg">
+                  <path d="M22 16.92v3a2 2 0 01-2.18 2 19.79 19.79 0 01-8.63-3.07A19.5 19.5 0 013.07 10.8 19.79 19.79 0 01.02 2.18 2 2 0 012 0h3a2 2 0 012 1.72c.127.96.361 1.903.7 2.81a2 2 0 01-.45 2.11L6.09 7.91a16 16 0 006 6l1.27-1.27a2 2 0 012.11-.45c.907.339 1.85.573 2.81.7A2 2 0 0122 14.92z"/>
+                </svg>
+              </div>
+              <h3 class="feature-title">Call Recording Consent</h3>
+              <p class="feature-desc">
+                Automated consent beeps, pre-call disclosures, and opt-out handling are
+                configurable per jurisdiction to keep every call legally compliant.
+              </p>
+            </article>
+
+            <article class="feature-card feature-card--compliance" id="feat-audit-logs">
+              <div class="feature-icon" aria-hidden="true">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" xmlns="http://www.w3.org/2000/svg">
+                  <path d="M14 2H6a2 2 0 00-2 2v16a2 2 0 002 2h12a2 2 0 002-2V8z"/>
+                  <polyline points="14 2 14 8 20 8"/>
+                  <line x1="8" y1="13" x2="16" y2="13"/>
+                  <line x1="8" y1="17" x2="16" y2="17"/>
+                  <line x1="8" y1="9" x2="12" y2="9"/>
+                </svg>
+              </div>
+              <h3 class="feature-title">Immutable Audit Logs</h3>
+              <p class="feature-desc">
+                Every system action — nudge delivery, escalation trigger, CRM write — is
+                logged with a tamper-evident timestamp for regulatory review and QA.
+              </p>
+            </article>
+
+            <article class="feature-card feature-card--compliance" id="feat-role-access">
+              <div class="feature-icon" aria-hidden="true">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" xmlns="http://www.w3.org/2000/svg">
+                  <rect x="3" y="11" width="18" height="11" rx="2" ry="2"/>
+                  <path d="M7 11V7a5 5 0 0110 0v4"/>
+                </svg>
+              </div>
+              <h3 class="feature-title">Role-Based Access Control</h3>
+              <p class="feature-desc">
+                Granular RBAC ensures agents, team leads, compliance officers, and admins
+                each see only the data and controls appropriate for their role.
+              </p>
+            </article>
+
+            <article class="feature-card feature-card--compliance" id="feat-guardrails">
+              <div class="feature-icon" aria-hidden="true">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" xmlns="http://www.w3.org/2000/svg">
+                  <circle cx="12" cy="12" r="10"/>
+                  <line x1="4.93" y1="4.93" x2="19.07" y2="19.07"/>
+                </svg>
+              </div>
+              <h3 class="feature-title">Compliance Guardrails</h3>
+              <p class="feature-desc">
+                Script compliance checks flag when agents deviate from required disclosures or
+                regulated language, with real-time alerts and post-call QA flagging.
+              </p>
+            </article>
+
+          </div>
+        </div>
+      </section>
+
+      <!-- ===================== CTA ===================== -->
+      <section class="section features-cta" id="features-cta">
+        <div class="container features-cta-inner">
+          <div class="features-cta-copy" data-reveal>
+            <p class="eyebrow">Ready to Deploy</p>
+            <h2>See every feature in your call-flow context.</h2>
+            <p>
+              Book a 30-minute demo and walk through AssistIQ and VoiceOS against your
+              actual call types, objection patterns, and language mix. We will show you
+              where the revenue leaks are and how quickly VOCA closes them.
+            </p>
+            <ul class="cta-bullets">
+              <li>Live walkthrough of AssistIQ nudges in your sales scenario</li>
+              <li>VoiceOS demo in the languages your team handles daily</li>
+              <li>Integration map to your existing CRM and telephony stack</li>
+              <li>Deployment timeline and ROI model in under 30 minutes</li>
+            </ul>
+            <a class="btn btn-primary" href="index.html#cta">Book a Demo</a>
+          </div>
+          <div class="features-cta-stats" data-reveal>
+            <article class="cta-stat">
+              <span class="cta-stat-value">15%</span>
+              <span class="cta-stat-label">Conversion uplift potential</span>
+            </article>
+            <article class="cta-stat">
+              <span class="cta-stat-value">20%</span>
+              <span class="cta-stat-label">Near-miss recovery potential</span>
+            </article>
+            <article class="cta-stat">
+              <span class="cta-stat-value">23+</span>
+              <span class="cta-stat-label">Indic languages supported</span>
+            </article>
+            <article class="cta-stat">
+              <span class="cta-stat-value">2 wks</span>
+              <span class="cta-stat-label">Typical time to first value</span>
+            </article>
+          </div>
+        </div>
+      </section>
+
+    </main>
+
+    <footer class="site-footer">
+      <div class="container footer-inner">
+        <p>VOCA AI | AI-native conversational intelligence for revenue voice operations.</p>
+        <p>&copy; <span id="year"></span> VOCA AI. All rights reserved.</p>
+      </div>
+    </footer>
+
+    <div class="toast" id="toast" role="status" aria-live="polite"></div>
+
+    <script src="https://cdn.jsdelivr.net/npm/gsap@3.13.0/dist/gsap.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/gsap@3.13.0/dist/ScrollTrigger.min.js"></script>
+    <script src="features.js"></script>
+  </body>
+</html>

--- a/features.js
+++ b/features.js
@@ -1,0 +1,295 @@
+(() => {
+  const reducedMotion = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+
+  // ─── 1. Reveal animations ────────────────────────────────────────────────────
+  function initRevealCards() {
+    if (!("IntersectionObserver" in window)) {
+      document.querySelectorAll(".feature-card").forEach((card) => {
+        card.classList.add("visible");
+      });
+      return;
+    }
+
+    const cards = document.querySelectorAll(".feature-card");
+    if (!cards.length) {
+      return;
+    }
+
+    const revealObserver = new IntersectionObserver(
+      (entries) => {
+        entries.forEach((entry) => {
+          if (entry.isIntersecting) {
+            entry.target.classList.add("visible");
+            revealObserver.unobserve(entry.target);
+          }
+        });
+      },
+      {
+        rootMargin: "0px 0px -10% 0px",
+        threshold: 0.1
+      }
+    );
+
+    cards.forEach((card) => revealObserver.observe(card));
+  }
+
+  // ─── 2. Sticky subnav highlight ──────────────────────────────────────────────
+  function initSubnavHighlight() {
+    const subnav = document.querySelector(".features-subnav");
+    if (!subnav) {
+      return;
+    }
+
+    const navLinks = Array.from(subnav.querySelectorAll("a[href^='#']"));
+    if (!navLinks.length) {
+      return;
+    }
+
+    const sections = navLinks
+      .map((link) => {
+        const id = link.getAttribute("href");
+        if (!id) {
+          return null;
+        }
+        const section = document.querySelector(id);
+        if (!(section instanceof HTMLElement)) {
+          return null;
+        }
+        return { link, section };
+      })
+      .filter(Boolean);
+
+    if (!sections.length || !("IntersectionObserver" in window)) {
+      return;
+    }
+
+    function setActiveNavLink(activeLink) {
+      navLinks.forEach((link) => {
+        link.classList.toggle("active", link === activeLink);
+      });
+    }
+
+    // Compute offset of subnav + site header so rootMargin accounts for sticky bars.
+    function getTopOffset() {
+      const header = document.querySelector(".site-header");
+      const headerH = header instanceof HTMLElement ? header.offsetHeight : 0;
+      const subnavH = subnav instanceof HTMLElement ? subnav.offsetHeight : 0;
+      return headerH + subnavH;
+    }
+
+    const visibilityMap = new Map();
+    const sectionObserver = new IntersectionObserver(
+      (entries) => {
+        entries.forEach((entry) => {
+          if (entry.isIntersecting) {
+            visibilityMap.set(entry.target, entry.intersectionRatio);
+          } else {
+            visibilityMap.delete(entry.target);
+          }
+        });
+
+        if (!visibilityMap.size) {
+          return;
+        }
+
+        const bestVisible = [...visibilityMap.entries()].sort((a, b) => b[1] - a[1])[0][0];
+        const match = sections.find((item) => item.section === bestVisible);
+        if (match) {
+          setActiveNavLink(match.link);
+        }
+      },
+      {
+        rootMargin: `-${getTopOffset() + 8}px 0px -40% 0px`,
+        threshold: [0.1, 0.25, 0.5]
+      }
+    );
+
+    sections.forEach((item) => sectionObserver.observe(item.section));
+
+    // Activate first link by default.
+    if (sections.length) {
+      setActiveNavLink(sections[0].link);
+    }
+  }
+
+  // ─── 3. Counter animations ───────────────────────────────────────────────────
+  function initCounters() {
+    const counterElements = document.querySelectorAll("[data-count-to]");
+    if (!counterElements.length) {
+      return;
+    }
+
+    if (reducedMotion || !("IntersectionObserver" in window)) {
+      counterElements.forEach((counter) => {
+        const target = Number(counter.getAttribute("data-count-to")) || 0;
+        const label = counter.parentElement?.querySelector(".metric-label")?.textContent || "";
+        counter.textContent = label.includes("%") ? `${target}%` : `${target}`;
+      });
+      return;
+    }
+
+    function animateCounter(counter) {
+      const target = Number(counter.getAttribute("data-count-to")) || 0;
+      const label = counter.parentElement?.querySelector(".metric-label")?.textContent || "";
+      const duration = 1200;
+      const start = performance.now();
+
+      function tick(now) {
+        const elapsed = Math.min(now - start, duration);
+        const progress = elapsed / duration;
+        // Ease out cubic
+        const eased = 1 - Math.pow(1 - progress, 3);
+        const current = Math.round(eased * target);
+        counter.textContent = label.includes("%") ? `${current}%` : `${current}`;
+        if (elapsed < duration) {
+          requestAnimationFrame(tick);
+        }
+      }
+
+      requestAnimationFrame(tick);
+    }
+
+    const counterObserver = new IntersectionObserver(
+      (entries) => {
+        entries.forEach((entry) => {
+          if (entry.isIntersecting) {
+            animateCounter(entry.target);
+            counterObserver.unobserve(entry.target);
+          }
+        });
+      },
+      {
+        rootMargin: "0px 0px -8% 0px",
+        threshold: 0.25
+      }
+    );
+
+    counterElements.forEach((counter) => counterObserver.observe(counter));
+  }
+
+  // ─── 4. Smooth scroll for subnav anchor links ────────────────────────────────
+  function initSmoothScroll() {
+    const subnav = document.querySelector(".features-subnav");
+    if (!subnav) {
+      return;
+    }
+
+    subnav.addEventListener("click", (event) => {
+      const target = event.target;
+      if (!(target instanceof HTMLElement)) {
+        return;
+      }
+      const anchor = target.closest("a[href^='#']");
+      if (!anchor) {
+        return;
+      }
+      const href = anchor.getAttribute("href");
+      if (!href) {
+        return;
+      }
+      const targetSection = document.querySelector(href);
+      if (!(targetSection instanceof HTMLElement)) {
+        return;
+      }
+
+      event.preventDefault();
+
+      const header = document.querySelector(".site-header");
+      const headerH = header instanceof HTMLElement ? header.offsetHeight : 0;
+      const subnavH = subnav instanceof HTMLElement ? subnav.offsetHeight : 0;
+      const offset = headerH + subnavH + 8;
+
+      const top = targetSection.getBoundingClientRect().top + window.scrollY - offset;
+      window.scrollTo({ top, behavior: "smooth" });
+    });
+  }
+
+  // ─── 5. Tilt effect on .feature-card.tilt-card ───────────────────────────────
+  function initTiltCards() {
+    if (reducedMotion || window.matchMedia("(hover: none)").matches) {
+      return;
+    }
+
+    const cards = document.querySelectorAll(".feature-card.tilt-card");
+    cards.forEach((card) => {
+      card.addEventListener("mousemove", (event) => {
+        const rect = card.getBoundingClientRect();
+        const x = (event.clientX - rect.left) / rect.width;
+        const y = (event.clientY - rect.top) / rect.height;
+        const rotateY = (x - 0.5) * 10;
+        const rotateX = (0.5 - y) * 10;
+        card.style.transform = `perspective(980px) rotateX(${rotateX.toFixed(2)}deg) rotateY(${rotateY.toFixed(2)}deg)`;
+      });
+
+      card.addEventListener("mouseleave", () => {
+        card.style.transform = "";
+      });
+    });
+  }
+
+  // ─── 6. Footer year ──────────────────────────────────────────────────────────
+  function initFooterYear() {
+    const yearSpan = document.getElementById("year");
+    if (yearSpan) {
+      yearSpan.textContent = String(new Date().getFullYear());
+    }
+  }
+
+  // ─── 7. Mobile nav toggle ────────────────────────────────────────────────────
+  function initMobileNav() {
+    const header = document.querySelector(".site-header");
+    if (!(header instanceof HTMLElement)) {
+      return;
+    }
+
+    const hamburger = header.querySelector(".nav-hamburger, [data-nav-toggle], .mobile-menu-toggle");
+    const mobileNav = header.querySelector(".mobile-nav, .nav-drawer, [data-mobile-nav]");
+
+    if (!hamburger || !mobileNav) {
+      return;
+    }
+
+    function setMenuState(open) {
+      const isOpen = Boolean(open);
+      hamburger.setAttribute("aria-expanded", String(isOpen));
+      mobileNav.classList.toggle("open", isOpen);
+      document.body.classList.toggle("nav-open", isOpen);
+    }
+
+    hamburger.addEventListener("click", () => {
+      const currentlyOpen = hamburger.getAttribute("aria-expanded") === "true";
+      setMenuState(!currentlyOpen);
+    });
+
+    // Close on outside click.
+    document.addEventListener("click", (event) => {
+      if (!(event.target instanceof Node)) {
+        return;
+      }
+      if (!header.contains(event.target)) {
+        setMenuState(false);
+      }
+    });
+
+    // Close on nav link click.
+    mobileNav.querySelectorAll("a").forEach((link) => {
+      link.addEventListener("click", () => setMenuState(false));
+    });
+
+    // Close on Escape.
+    document.addEventListener("keydown", (event) => {
+      if (event.key === "Escape") {
+        setMenuState(false);
+      }
+    });
+  }
+
+  // ─── Init ────────────────────────────────────────────────────────────────────
+  initRevealCards();
+  initSubnavHighlight();
+  initCounters();
+  initSmoothScroll();
+  initTiltCards();
+  initFooterYear();
+  initMobileNav();
+})();

--- a/index.html
+++ b/index.html
@@ -31,6 +31,7 @@
           </span>
         </a>
         <nav class="site-nav" aria-label="Primary Navigation">
+          <a href="features.html">Features</a>
           <a href="#products">Products</a>
           <a href="#assist-loop">Assist Loop</a>
           <a href="#voice-demo">Voice Demo</a>


### PR DESCRIPTION
## Summary
- Removes `@import url('./styles.css');` from `features.css` which violated the CSS spec (imports must precede all other rules)
- `features.html` already had both `<link rel="stylesheet" href="styles.css" />` and `<link rel="stylesheet" href="features.css" />` in the `<head>`, so no HTML changes were needed
- Parallel stylesheet loading is more performant than sequential `@import` resolution

## Test plan
- [ ] Verify features page renders identically with no visual regression
- [ ] Confirm no `@import` remains in `features.css`
- [ ] Confirm `features.html` loads both stylesheets via `<link>` tags

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)