### PR TITLE
fix: add script.js to features.html to restore dynamic content and animations

### DIFF
--- a/features.html
+++ b/features.html
@@ -1,0 +1,664 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>VOCA AI | Features — Every Capability in One Revenue Engine</title>
+    <meta
+      name="description"
+      content="Explore the full VOCA AI feature set: real-time intelligence, autonomous voice, analytics, integrations, and enterprise compliance."
+    />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;500;600;700;800&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="styles.css" />
+    <link rel="stylesheet" href="features.css" />
+  </head>
+  <body class="theme-minimal">
+    <div class="ambient ambient-a"></div>
+    <div class="ambient ambient-b"></div>
+    <div class="ambient ambient-c"></div>
+
+    <header class="site-header" id="top">
+      <div class="container header-inner">
+        <a class="brand" href="index.html" aria-label="VOCA AI Home">
+          <img class="brand-logo" src="assets/voca-logo.svg" alt="" aria-hidden="true" />
+          <span class="brand-lockup">
+            <span class="brand-text">VOCA AI</span>
+            <span class="brand-sub">Revenue Voice OS</span>
+          </span>
+        </a>
+        <nav class="site-nav" aria-label="Primary Navigation">
+          <a href="#realtime-intelligence">Real-Time AI</a>
+          <a href="#voice-autonomy">Voice Autonomy</a>
+          <a href="#analytics-coaching">Analytics</a>
+          <a href="#integrations">Integrations</a>
+          <a href="#compliance">Compliance</a>
+          <a href="index.html#cta">Book Demo</a>
+        </nav>
+        <a class="btn btn-small header-cta" href="index.html#cta">Talk to Sales</a>
+      </div>
+    </header>
+
+    <main>
+
+      <!-- ===================== HERO ===================== -->
+      <section class="section features-hero" id="features-hero">
+        <div class="container features-hero-inner">
+          <p class="eyebrow">The Complete Feature Stack</p>
+          <h1 class="features-hero-title">Every Feature. One Revenue Engine.</h1>
+          <p class="features-hero-subtitle">
+            AssistIQ and VoiceOS ship with everything your revenue team needs — from
+            live intent scoring and autonomous multilingual voice to enterprise-grade
+            compliance and plug-and-play CRM integrations.
+          </p>
+          <div class="features-hero-cta">
+            <a class="btn btn-primary" href="index.html#cta">Book a Demo</a>
+            <a class="btn btn-outline" href="#realtime-intelligence">Explore Features</a>
+          </div>
+          <nav class="features-anchor-nav" aria-label="Feature section anchors">
+            <a href="#realtime-intelligence">Real-Time Intelligence</a>
+            <a href="#voice-autonomy">Voice Autonomy</a>
+            <a href="#analytics-coaching">Analytics &amp; Coaching</a>
+            <a href="#integrations">Integrations</a>
+            <a href="#compliance">Compliance &amp; Security</a>
+          </nav>
+        </div>
+      </section>
+
+      <!-- ===================== REAL-TIME INTELLIGENCE ===================== -->
+      <section class="section features-section" id="realtime-intelligence">
+        <div class="container">
+          <div class="section-head" data-reveal>
+            <p class="eyebrow">VOCA AssistIQ</p>
+            <h2>Real-Time Intelligence</h2>
+            <p>
+              AssistIQ listens to every live call and delivers contextual nudges the moment they
+              matter — not after the conversation is over.
+            </p>
+          </div>
+          <div class="feature-grid" data-reveal>
+
+            <article class="feature-card" id="feat-intent-scoring">
+              <div class="feature-icon" aria-hidden="true">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" xmlns="http://www.w3.org/2000/svg">
+                  <circle cx="12" cy="12" r="10"/>
+                  <polyline points="12 6 12 12 16 14"/>
+                </svg>
+              </div>
+              <h3 class="feature-title">Live Intent Scoring</h3>
+              <p class="feature-desc">
+                Every utterance is scored for purchase intent, upsell readiness, and churn risk
+                in real time, giving agents a live signal map of where the conversation stands.
+              </p>
+            </article>
+
+            <article class="feature-card" id="feat-objection-detection">
+              <div class="feature-icon" aria-hidden="true">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" xmlns="http://www.w3.org/2000/svg">
+                  <path d="M10.29 3.86L1.82 18a2 2 0 001.71 3h16.94a2 2 0 001.71-3L13.71 3.86a2 2 0 00-3.42 0z"/>
+                  <line x1="12" y1="9" x2="12" y2="13"/>
+                  <line x1="12" y1="17" x2="12.01" y2="17"/>
+                </svg>
+              </div>
+              <h3 class="feature-title">Objection Detection</h3>
+              <p class="feature-desc">
+                Common objection patterns are identified the moment they surface. Agents receive
+                real-time response prompts drawn from top-performer playbooks.
+              </p>
+            </article>
+
+            <article class="feature-card" id="feat-nba-nudges">
+              <div class="feature-icon" aria-hidden="true">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" xmlns="http://www.w3.org/2000/svg">
+                  <polygon points="13 2 3 14 12 14 11 22 21 10 12 10 13 2"/>
+                </svg>
+              </div>
+              <h3 class="feature-title">Next-Best-Action Nudges</h3>
+              <p class="feature-desc">
+                Context-aware suggestions for upsell, cross-sell, offer framing, and escalation
+                delivered directly to the agent's screen without interrupting the call.
+              </p>
+            </article>
+
+            <article class="feature-card" id="feat-sentiment-analysis">
+              <div class="feature-icon" aria-hidden="true">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" xmlns="http://www.w3.org/2000/svg">
+                  <circle cx="12" cy="12" r="10"/>
+                  <path d="M8 14s1.5 2 4 2 4-2 4-2"/>
+                  <line x1="9" y1="9" x2="9.01" y2="9"/>
+                  <line x1="15" y1="9" x2="15.01" y2="9"/>
+                </svg>
+              </div>
+              <h3 class="feature-title">Sentiment Analysis</h3>
+              <p class="feature-desc">
+                Continuous tone and sentiment tracking surfaces frustration, hesitation, and
+                enthusiasm in real time so agents can modulate and managers can intervene.
+              </p>
+            </article>
+
+            <article class="feature-card" id="feat-near-miss-recovery">
+              <div class="feature-icon" aria-hidden="true">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" xmlns="http://www.w3.org/2000/svg">
+                  <path d="M22 11.08V12a10 10 0 11-5.93-9.14"/>
+                  <polyline points="22 4 12 14.01 9 11.01"/>
+                </svg>
+              </div>
+              <h3 class="feature-title">Near-Miss Recovery</h3>
+              <p class="feature-desc">
+                When a high-intent call drops without conversion, AssistIQ automatically
+                triggers prioritised callback queues, SMS follow-ups, and email reachout flows.
+              </p>
+            </article>
+
+            <article class="feature-card" id="feat-silence-detection">
+              <div class="feature-icon" aria-hidden="true">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" xmlns="http://www.w3.org/2000/svg">
+                  <line x1="1" y1="1" x2="23" y2="23"/>
+                  <path d="M9 9v3a3 3 0 005.12 2.12M15 9.34V4a3 3 0 00-5.94-.6"/>
+                  <path d="M17 16.95A7 7 0 015 12v-2m14 0v2a7 7 0 01-.11 1.23"/>
+                  <line x1="12" y1="19" x2="12" y2="23"/>
+                  <line x1="8" y1="23" x2="16" y2="23"/>
+                </svg>
+              </div>
+              <h3 class="feature-title">Dead-Air &amp; Silence Detection</h3>
+              <p class="feature-desc">
+                Prolonged silences trigger instant coaching prompts to help agents re-engage
+                prospects and avoid call drops due to awkward pauses.
+              </p>
+            </article>
+
+          </div>
+        </div>
+      </section>
+
+      <!-- ===================== VOICE AUTONOMY ===================== -->
+      <section class="section features-section features-section--alt" id="voice-autonomy">
+        <div class="container">
+          <div class="section-head" data-reveal>
+            <p class="eyebrow">VOCA VoiceOS</p>
+            <h2>Voice Autonomy</h2>
+            <p>
+              VoiceOS is a production-grade autonomous voice stack that handles full
+              inbound and outbound conversations across 23 Indic languages and English.
+            </p>
+          </div>
+          <div class="feature-grid" data-reveal>
+
+            <article class="feature-card" id="feat-multilingual-ivr">
+              <div class="feature-icon" aria-hidden="true">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" xmlns="http://www.w3.org/2000/svg">
+                  <circle cx="12" cy="12" r="10"/>
+                  <line x1="2" y1="12" x2="22" y2="12"/>
+                  <path d="M12 2a15.3 15.3 0 014 10 15.3 15.3 0 01-4 10 15.3 15.3 0 01-4-10 15.3 15.3 0 014-10z"/>
+                </svg>
+              </div>
+              <h3 class="feature-title">Multilingual IVR</h3>
+              <p class="feature-desc">
+                Replace rigid DTMF trees with natural-language IVR that understands and
+                responds across Hindi, Tamil, Telugu, Kannada, Bengali, Marathi, and 17 more
+                Indic languages plus English.
+              </p>
+            </article>
+
+            <article class="feature-card" id="feat-voice-synthesis">
+              <div class="feature-icon" aria-hidden="true">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" xmlns="http://www.w3.org/2000/svg">
+                  <path d="M12 1a3 3 0 00-3 3v8a3 3 0 006 0V4a3 3 0 00-3-3z"/>
+                  <path d="M19 10v2a7 7 0 01-14 0v-2"/>
+                  <line x1="12" y1="19" x2="12" y2="23"/>
+                  <line x1="8" y1="23" x2="16" y2="23"/>
+                </svg>
+              </div>
+              <h3 class="feature-title">Human-Like Voice Synthesis</h3>
+              <p class="feature-desc">
+                Low-latency neural TTS produces natural prosody, appropriate pausing, and
+                human-style turn-taking so callers cannot distinguish the AI from a live agent.
+              </p>
+            </article>
+
+            <article class="feature-card" id="feat-accent-coverage">
+              <div class="feature-icon" aria-hidden="true">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" xmlns="http://www.w3.org/2000/svg">
+                  <polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2"/>
+                </svg>
+              </div>
+              <h3 class="feature-title">Accent Coverage</h3>
+              <p class="feature-desc">
+                ASR models fine-tuned on regional accent variations ensure accurate speech
+                recognition regardless of dialect, code-switching, or mixed-language utterances.
+              </p>
+            </article>
+
+            <article class="feature-card" id="feat-call-routing">
+              <div class="feature-icon" aria-hidden="true">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" xmlns="http://www.w3.org/2000/svg">
+                  <polyline points="22 12 18 12 15 21 9 3 6 12 2 12"/>
+                </svg>
+              </div>
+              <h3 class="feature-title">Intelligent Call Routing</h3>
+              <p class="feature-desc">
+                Intent and language signals dynamically route calls to the right queue, agent
+                skill-set, or VoiceOS flow — eliminating manual dispatch and misrouting delays.
+              </p>
+            </article>
+
+            <article class="feature-card" id="feat-human-handoff">
+              <div class="feature-icon" aria-hidden="true">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" xmlns="http://www.w3.org/2000/svg">
+                  <path d="M17 21v-2a4 4 0 00-4-4H5a4 4 0 00-4 4v2"/>
+                  <circle cx="9" cy="7" r="4"/>
+                  <path d="M23 21v-2a4 4 0 00-3-3.87"/>
+                  <path d="M16 3.13a4 4 0 010 7.75"/>
+                </svg>
+              </div>
+              <h3 class="feature-title">Controlled Human Handoff</h3>
+              <p class="feature-desc">
+                Confidence-gated escalation hands complex or high-value interactions to live
+                agents with full context transfer — no caller repetition, no context loss.
+              </p>
+            </article>
+
+            <article class="feature-card" id="feat-inbound-outbound">
+              <div class="feature-icon" aria-hidden="true">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" xmlns="http://www.w3.org/2000/svg">
+                  <line x1="7" y1="17" x2="17" y2="7"/>
+                  <polyline points="7 7 17 7 17 17"/>
+                </svg>
+              </div>
+              <h3 class="feature-title">Inbound &amp; Outbound Flows</h3>
+              <p class="feature-desc">
+                VoiceOS manages both inbound resolution and outbound dialer campaigns — from
+                collections and renewals to lead qualification and appointment setting.
+              </p>
+            </article>
+
+          </div>
+        </div>
+      </section>
+
+      <!-- ===================== ANALYTICS & COACHING ===================== -->
+      <section class="section features-section" id="analytics-coaching">
+        <div class="container">
+          <div class="section-head" data-reveal>
+            <p class="eyebrow">Performance Intelligence</p>
+            <h2>Analytics &amp; Coaching</h2>
+            <p>
+              Close the loop from every call into structured coaching data. VOCA turns
+              conversation outcomes into rep growth, team trends, and manager-ready insights.
+            </p>
+          </div>
+          <div class="feature-grid" data-reveal>
+
+            <article class="feature-card" id="feat-post-call-summaries">
+              <div class="feature-icon" aria-hidden="true">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" xmlns="http://www.w3.org/2000/svg">
+                  <path d="M14 2H6a2 2 0 00-2 2v16a2 2 0 002 2h12a2 2 0 002-2V8z"/>
+                  <polyline points="14 2 14 8 20 8"/>
+                  <line x1="16" y1="13" x2="8" y2="13"/>
+                  <line x1="16" y1="17" x2="8" y2="17"/>
+                  <polyline points="10 9 9 9 8 9"/>
+                </svg>
+              </div>
+              <h3 class="feature-title">Post-Call Summaries</h3>
+              <p class="feature-desc">
+                Auto-generated structured summaries capture intent signals, objections raised,
+                outcomes, and suggested follow-up actions — pushed directly to your CRM.
+              </p>
+            </article>
+
+            <article class="feature-card" id="feat-rep-scorecards">
+              <div class="feature-icon" aria-hidden="true">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" xmlns="http://www.w3.org/2000/svg">
+                  <rect x="2" y="3" width="20" height="14" rx="2" ry="2"/>
+                  <line x1="8" y1="21" x2="16" y2="21"/>
+                  <line x1="12" y1="17" x2="12" y2="21"/>
+                </svg>
+              </div>
+              <h3 class="feature-title">Rep Scorecards</h3>
+              <p class="feature-desc">
+                Individual performance profiles track nudge acceptance rate, objection handling
+                score, conversion by call type, and talk-to-listen ratio over time.
+              </p>
+            </article>
+
+            <article class="feature-card" id="feat-trend-dashboards">
+              <div class="feature-icon" aria-hidden="true">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" xmlns="http://www.w3.org/2000/svg">
+                  <line x1="18" y1="20" x2="18" y2="10"/>
+                  <line x1="12" y1="20" x2="12" y2="4"/>
+                  <line x1="6" y1="20" x2="6" y2="14"/>
+                </svg>
+              </div>
+              <h3 class="feature-title">Trend Dashboards</h3>
+              <p class="feature-desc">
+                Real-time and historical dashboards surface conversion trends, objection
+                frequency by product, language breakdown, and queue-level performance.
+              </p>
+            </article>
+
+            <article class="feature-card" id="feat-manager-alerts">
+              <div class="feature-icon" aria-hidden="true">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" xmlns="http://www.w3.org/2000/svg">
+                  <path d="M18 8A6 6 0 006 8c0 7-3 9-3 9h18s-3-2-3-9"/>
+                  <path d="M13.73 21a2 2 0 01-3.46 0"/>
+                </svg>
+              </div>
+              <h3 class="feature-title">Manager Alerts</h3>
+              <p class="feature-desc">
+                Live alerts notify team leads when a call is at risk, when a rep ignores
+                repeated nudges, or when a high-value prospect goes cold after a missed drop.
+              </p>
+            </article>
+
+            <article class="feature-card" id="feat-coaching-loops">
+              <div class="feature-icon" aria-hidden="true">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" xmlns="http://www.w3.org/2000/svg">
+                  <polyline points="23 4 23 10 17 10"/>
+                  <polyline points="1 20 1 14 7 14"/>
+                  <path d="M3.51 9a9 9 0 0114.85-3.36L23 10M1 14l4.64 4.36A9 9 0 0020.49 15"/>
+                </svg>
+              </div>
+              <h3 class="feature-title">Automated Coaching Loops</h3>
+              <p class="feature-desc">
+                Call outcomes feed back into rep coaching plans automatically. Best-performer
+                behavior is captured and distributed across the team at scale.
+              </p>
+            </article>
+
+            <article class="feature-card" id="feat-call-transcripts">
+              <div class="feature-icon" aria-hidden="true">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" xmlns="http://www.w3.org/2000/svg">
+                  <line x1="21" y1="10" x2="7" y2="10"/>
+                  <line x1="21" y1="6" x2="3" y2="6"/>
+                  <line x1="21" y1="14" x2="3" y2="14"/>
+                  <line x1="21" y1="18" x2="7" y2="18"/>
+                </svg>
+              </div>
+              <h3 class="feature-title">Searchable Call Transcripts</h3>
+              <p class="feature-desc">
+                Every call is transcribed, tagged by topic, and indexed for full-text search —
+                enabling QA teams to surface specific moments in seconds.
+              </p>
+            </article>
+
+          </div>
+        </div>
+      </section>
+
+      <!-- ===================== INTEGRATIONS ===================== -->
+      <section class="section features-section features-section--alt" id="integrations">
+        <div class="container">
+          <div class="section-head" data-reveal>
+            <p class="eyebrow">Plug-and-Play Connectivity</p>
+            <h2>Integrations</h2>
+            <p>
+              VOCA plugs into the tools your revenue team already uses — no rip-and-replace
+              required. Native connectors keep data flowing in both directions.
+            </p>
+          </div>
+
+          <div class="integration-categories" data-reveal>
+
+            <div class="integration-category" id="integ-crm">
+              <h3 class="integration-category-title">CRM</h3>
+              <p class="integration-category-desc">
+                Bi-directional sync pushes post-call summaries, intent scores, and follow-up
+                tasks into your existing CRM workflow automatically after every call.
+              </p>
+              <ul class="integration-list">
+                <li class="integration-item">
+                  <span class="integration-name">Salesforce</span>
+                  <span class="integration-detail">Opportunity updates, task creation, custom field mapping</span>
+                </li>
+                <li class="integration-item">
+                  <span class="integration-name">HubSpot</span>
+                  <span class="integration-detail">Contact activity timeline, deal stage progression</span>
+                </li>
+                <li class="integration-item">
+                  <span class="integration-name">Zoho CRM</span>
+                  <span class="integration-detail">Lead scoring sync, call log enrichment</span>
+                </li>
+                <li class="integration-item">
+                  <span class="integration-name">Leadsquared</span>
+                  <span class="integration-detail">Pipeline updates, disposition capture</span>
+                </li>
+              </ul>
+            </div>
+
+            <div class="integration-category" id="integ-telephony">
+              <h3 class="integration-category-title">Telephony &amp; Dialer</h3>
+              <p class="integration-category-desc">
+                Connect to your existing telephony stack via certified integrations — no change
+                to your dialer configuration or call recording workflow.
+              </p>
+              <ul class="integration-list">
+                <li class="integration-item">
+                  <span class="integration-name">Exotel</span>
+                  <span class="integration-detail">Real-time audio stream, call event webhooks</span>
+                </li>
+                <li class="integration-item">
+                  <span class="integration-name">Twilio</span>
+                  <span class="integration-detail">MediaStream API, Flex integration</span>
+                </li>
+                <li class="integration-item">
+                  <span class="integration-name">NICE CXone</span>
+                  <span class="integration-detail">ACD integration, agent workspace embed</span>
+                </li>
+                <li class="integration-item">
+                  <span class="integration-name">Genesys</span>
+                  <span class="integration-detail">AudioHook, cloud telephony connectors</span>
+                </li>
+              </ul>
+            </div>
+
+            <div class="integration-category" id="integ-helpdesk">
+              <h3 class="integration-category-title">Helpdesk &amp; Support</h3>
+              <p class="integration-category-desc">
+                Route post-call actions and escalations directly into your support ticketing
+                platform to keep voice and digital service channels aligned.
+              </p>
+              <ul class="integration-list">
+                <li class="integration-item">
+                  <span class="integration-name">Zendesk</span>
+                  <span class="integration-detail">Ticket auto-creation, CSAT alignment</span>
+                </li>
+                <li class="integration-item">
+                  <span class="integration-name">Freshdesk</span>
+                  <span class="integration-detail">Conversation linking, agent notes sync</span>
+                </li>
+                <li class="integration-item">
+                  <span class="integration-name">Intercom</span>
+                  <span class="integration-detail">User event tagging from call outcomes</span>
+                </li>
+              </ul>
+            </div>
+
+            <div class="integration-category" id="integ-bi">
+              <h3 class="integration-category-title">Analytics &amp; BI</h3>
+              <p class="integration-category-desc">
+                Push conversation intelligence into your existing BI stack for cross-channel
+                revenue analysis and executive reporting.
+              </p>
+              <ul class="integration-list">
+                <li class="integration-item">
+                  <span class="integration-name">Tableau</span>
+                  <span class="integration-detail">Pre-built voice analytics connector</span>
+                </li>
+                <li class="integration-item">
+                  <span class="integration-name">Looker / BigQuery</span>
+                  <span class="integration-detail">Event stream export, custom dimensions</span>
+                </li>
+                <li class="integration-item">
+                  <span class="integration-name">Webhook API</span>
+                  <span class="integration-detail">Real-time event push to any downstream system</span>
+                </li>
+              </ul>
+            </div>
+
+          </div>
+        </div>
+      </section>
+
+      <!-- ===================== COMPLIANCE & SECURITY ===================== -->
+      <section class="section features-section" id="compliance">
+        <div class="container">
+          <div class="section-head" data-reveal>
+            <p class="eyebrow">Enterprise Trust</p>
+            <h2>Compliance &amp; Security</h2>
+            <p>
+              VOCA is built for regulated industries. Every deployment ships with the
+              controls, consent mechanisms, and audit infrastructure enterprise teams require.
+            </p>
+          </div>
+          <div class="feature-grid" data-reveal>
+
+            <article class="feature-card feature-card--compliance" id="feat-pci-dss">
+              <div class="feature-icon" aria-hidden="true">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" xmlns="http://www.w3.org/2000/svg">
+                  <rect x="1" y="4" width="22" height="16" rx="2" ry="2"/>
+                  <line x1="1" y1="10" x2="23" y2="10"/>
+                </svg>
+              </div>
+              <h3 class="feature-title">PCI-DSS Ready</h3>
+              <p class="feature-desc">
+                Payment card data is masked and redacted from call recordings and transcripts.
+                DTMF capture for card entry never traverses VOCA systems in clear text.
+              </p>
+            </article>
+
+            <article class="feature-card feature-card--compliance" id="feat-gdpr">
+              <div class="feature-icon" aria-hidden="true">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" xmlns="http://www.w3.org/2000/svg">
+                  <path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/>
+                </svg>
+              </div>
+              <h3 class="feature-title">GDPR-Ready</h3>
+              <p class="feature-desc">
+                Data residency controls, right-to-erasure workflows, and configurable
+                retention policies support GDPR and DPDP Act compliance requirements.
+              </p>
+            </article>
+
+            <article class="feature-card feature-card--compliance" id="feat-call-consent">
+              <div class="feature-icon" aria-hidden="true">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" xmlns="http://www.w3.org/2000/svg">
+                  <path d="M22 16.92v3a2 2 0 01-2.18 2 19.79 19.79 0 01-8.63-3.07A19.5 19.5 0 013.07 10.8 19.79 19.79 0 01.02 2.18 2 2 0 012 0h3a2 2 0 012 1.72c.127.96.361 1.903.7 2.81a2 2 0 01-.45 2.11L6.09 7.91a16 16 0 006 6l1.27-1.27a2 2 0 012.11-.45c.907.339 1.85.573 2.81.7A2 2 0 0122 14.92z"/>
+                </svg>
+              </div>
+              <h3 class="feature-title">Call Recording Consent</h3>
+              <p class="feature-desc">
+                Automated consent beeps, pre-call disclosures, and opt-out handling are
+                configurable per jurisdiction to keep every call legally compliant.
+              </p>
+            </article>
+
+            <article class="feature-card feature-card--compliance" id="feat-audit-logs">
+              <div class="feature-icon" aria-hidden="true">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" xmlns="http://www.w3.org/2000/svg">
+                  <path d="M14 2H6a2 2 0 00-2 2v16a2 2 0 002 2h12a2 2 0 002-2V8z"/>
+                  <polyline points="14 2 14 8 20 8"/>
+                  <line x1="8" y1="13" x2="16" y2="13"/>
+                  <line x1="8" y1="17" x2="16" y2="17"/>
+                  <line x1="8" y1="9" x2="12" y2="9"/>
+                </svg>
+              </div>
+              <h3 class="feature-title">Immutable Audit Logs</h3>
+              <p class="feature-desc">
+                Every system action — nudge delivery, escalation trigger, CRM write — is
+                logged with a tamper-evident timestamp for regulatory review and QA.
+              </p>
+            </article>
+
+            <article class="feature-card feature-card--compliance" id="feat-role-access">
+              <div class="feature-icon" aria-hidden="true">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" xmlns="http://www.w3.org/2000/svg">
+                  <rect x="3" y="11" width="18" height="11" rx="2" ry="2"/>
+                  <path d="M7 11V7a5 5 0 0110 0v4"/>
+                </svg>
+              </div>
+              <h3 class="feature-title">Role-Based Access Control</h3>
+              <p class="feature-desc">
+                Granular RBAC ensures agents, team leads, compliance officers, and admins
+                each see only the data and controls appropriate for their role.
+              </p>
+            </article>
+
+            <article class="feature-card feature-card--compliance" id="feat-guardrails">
+              <div class="feature-icon" aria-hidden="true">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" xmlns="http://www.w3.org/2000/svg">
+                  <circle cx="12" cy="12" r="10"/>
+                  <line x1="4.93" y1="4.93" x2="19.07" y2="19.07"/>
+                </svg>
+              </div>
+              <h3 class="feature-title">Compliance Guardrails</h3>
+              <p class="feature-desc">
+                Script compliance checks flag when agents deviate from required disclosures or
+                regulated language, with real-time alerts and post-call QA flagging.
+              </p>
+            </article>
+
+          </div>
+        </div>
+      </section>
+
+      <!-- ===================== CTA ===================== -->
+      <section class="section features-cta" id="features-cta">
+        <div class="container features-cta-inner">
+          <div class="features-cta-copy" data-reveal>
+            <p class="eyebrow">Ready to Deploy</p>
+            <h2>See every feature in your call-flow context.</h2>
+            <p>
+              Book a 30-minute demo and walk through AssistIQ and VoiceOS against your
+              actual call types, objection patterns, and language mix. We will show you
+              where the revenue leaks are and how quickly VOCA closes them.
+            </p>
+            <ul class="cta-bullets">
+              <li>Live walkthrough of AssistIQ nudges in your sales scenario</li>
+              <li>VoiceOS demo in the languages your team handles daily</li>
+              <li>Integration map to your existing CRM and telephony stack</li>
+              <li>Deployment timeline and ROI model in under 30 minutes</li>
+            </ul>
+            <a class="btn btn-primary" href="index.html#cta">Book a Demo</a>
+          </div>
+          <div class="features-cta-stats" data-reveal>
+            <article class="cta-stat">
+              <span class="cta-stat-value">15%</span>
+              <span class="cta-stat-label">Conversion uplift potential</span>
+            </article>
+            <article class="cta-stat">
+              <span class="cta-stat-value">20%</span>
+              <span class="cta-stat-label">Near-miss recovery potential</span>
+            </article>
+            <article class="cta-stat">
+              <span class="cta-stat-value">23+</span>
+              <span class="cta-stat-label">Indic languages supported</span>
+            </article>
+            <article class="cta-stat">
+              <span class="cta-stat-value">2 wks</span>
+              <span class="cta-stat-label">Typical time to first value</span>
+            </article>
+          </div>
+        </div>
+      </section>
+
+    </main>
+
+    <footer class="site-footer">
+      <div class="container footer-inner">
+        <p>VOCA AI | AI-native conversational intelligence for revenue voice operations.</p>
+        <p>&copy; <span id="year"></span> VOCA AI. All rights reserved.</p>
+      </div>
+    </footer>
+
+    <div class="toast" id="toast" role="status" aria-live="polite"></div>
+
+    <script src="https://cdn.jsdelivr.net/npm/gsap@3.13.0/dist/gsap.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/gsap@3.13.0/dist/ScrollTrigger.min.js"></script>
+    <script src="script.js"></script>
+    <script src="features.js"></script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary

- Added `<script src="script.js"></script>` before `features.js` in `features.html`
- This restores `renderCopy()`, wave canvas animations (`initWaveCanvases()`), and shared init logic on the features page

## Test plan

- [ ] Open `features.html` in a browser — no JS console errors on load
- [ ] Canvas wave animations render correctly
- [ ] Template-driven content from `renderCopy()` appears

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)