### PR TITLE
fix: add sr-only accessibility fallback content for canvas elements

### DIFF
--- a/index.html
+++ b/index.html
@@ -89,6 +89,7 @@
             <div class="hero-floating hero-floating-a">AssistIQ nudges live</div>
             <div class="hero-floating hero-floating-b">VoiceOS multi-language active</div>
             <canvas id="hero-wave" width="640" height="420" aria-hidden="true"></canvas>
+            <p class="sr-only">Animated visualization of VOCA AI's voice processing pipeline</p>
             <div class="hero-glass">
               <p class="glass-label">Live Intent Stream</p>
               <ul class="live-feed">
@@ -223,6 +224,7 @@
             data-wave-tone="coral"
             aria-hidden="true"
           ></canvas>
+          <p class="sr-only">Animated waveform representing the AssistIQ revenue loop — live nudges and post-call follow-up workflows that keep high-intent leads in motion</p>
           <div class="assist-loop-grid" id="assist-loop-grid"></div>
         </div>
       </section>
@@ -272,6 +274,7 @@
             data-wave-tone="teal"
             aria-hidden="true"
           ></canvas>
+          <p class="sr-only">Animated waveform representing VOCA VoiceOS audio quality — waveform intelligence visualization for voice model review</p>
           <div class="demo-grid">
             <article class="audio-card" data-reveal>
               <div class="audio-header">
@@ -280,6 +283,7 @@
               </div>
               <audio id="demo-audio" preload="metadata" src="assets/voca-demo.mp3"></audio>
               <canvas id="audio-visualizer" width="640" height="200" aria-hidden="true"></canvas>
+              <p class="sr-only">Real-time audio waveform visualizer for the VOCA demo audio playback</p>
 
               <div class="audio-controls">
                 <button type="button" class="btn btn-primary btn-small" id="play-toggle">

--- a/styles.css
+++ b/styles.css
@@ -2,6 +2,19 @@
    VOCA AI — SKEW MORPHISM + GLASSMORPHISM THEME
    ══════════════════════════════════════════════════════════════ */
 
+/* Accessibility utility */
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
 :root {
   /* Dark base */
   --bg-void:    #040408;


### PR DESCRIPTION
## Summary

- Adds `.sr-only` CSS utility class to `styles.css` (WCAG-standard visually-hidden pattern)
- Adds adjacent `<p class="sr-only">` descriptions for each meaningful canvas element:
  - `#hero-wave` — describes VOCA AI's voice processing pipeline visualization
  - `#assist-wave` — describes the AssistIQ revenue loop waveform
  - `#voice-wave` — describes the VoiceOS audio quality waveform
  - `#audio-visualizer` — describes the real-time demo audio visualizer
- `#wave-divider-leak` is already inside `<div aria-hidden="true">` and requires no fallback

## Test plan

- [ ] Run WAVE or axe accessibility scan — no canvas-related errors should appear
- [ ] Verify `.sr-only` elements are not visible on screen
- [ ] Verify screen reader announces the descriptions when navigating to those sections

Closes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)