### PR TITLE
feat: new brutalist UI redesign

### DIFF
--- a/index.html
+++ b/index.html
@@ -21,7 +21,7 @@
     <div class="ambient ambient-b"></div>
     <div class="ambient ambient-c"></div>
 
-    <header class="site-header" id="top">
+    <header class="site-header" id="top" data-testid="header">
       <div class="container header-inner">
         <a class="brand" href="#top" aria-label="VOCA AI Home">
           <img class="brand-logo" src="assets/voca-logo.svg" alt="" aria-hidden="true" />
@@ -42,7 +42,7 @@
     </header>
 
     <main>
-      <section class="section hero" id="hero">
+      <section class="section hero" id="hero" data-testid="hero">
         <div class="container hero-grid">
           <div class="hero-copy">
             <p class="eyebrow" id="hero-eyebrow" data-hero-stagger></p>
@@ -205,7 +205,7 @@
         </div>
       </section>
 
-      <section class="section assist-loop" id="assist-loop">
+      <section class="section assist-loop" id="assist-loop" data-testid="assist-loop">
         <div class="container">
           <div class="section-head" data-reveal>
             <p class="eyebrow">AssistIQ Revenue Loop</p>
@@ -255,7 +255,7 @@
         </div>
       </section>
 
-      <section class="section voice-demo" id="voice-demo">
+      <section class="section voice-demo" id="voice-demo" data-testid="voice-demo">
         <div class="container">
           <div class="section-head" data-reveal>
             <p class="eyebrow">Voice Demo</p>
@@ -392,7 +392,7 @@
         </div>
       </section>
 
-      <section class="section cta" id="cta">
+      <section class="section cta" id="cta" data-testid="cta">
         <div class="container cta-grid">
           <div class="cta-copy" data-reveal>
             <p class="eyebrow">Book a Demo</p>

--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
-      href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;500;600;700;800;900&display=swap"
+      href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&display=swap"
       rel="stylesheet"
     />
     <link rel="stylesheet" href="styles.css" />

--- a/script.js
+++ b/script.js
@@ -561,7 +561,7 @@
       const height = visualizer.height;
       canvasCtx.clearRect(0, 0, width, height);
 
-      canvasCtx.fillStyle = "rgba(4, 4, 12, 0.95)";
+      canvasCtx.fillStyle = "rgba(10, 10, 10, 0.97)";
       canvasCtx.fillRect(0, 0, width, height);
 
       const barWidth = width / dataArray.length;
@@ -570,14 +570,14 @@
         const barHeight = (value / 255) * (height - 20);
         const x = i * barWidth;
         const y = height - barHeight;
-        const hue = 260 + (i / dataArray.length) * 60;
-        canvasCtx.fillStyle = `hsla(${hue}, 80%, 65%, 0.88)`;
+        const t = i / dataArray.length;
+        canvasCtx.fillStyle = t < 0.5 ? `rgba(255,229,0,${0.7 + t * 0.4})` : `rgba(0,71,255,${0.7 + (1-t) * 0.4})`;
         canvasCtx.fillRect(x, y, Math.max(1, barWidth - 2), barHeight);
       }
 
       canvasCtx.beginPath();
       canvasCtx.lineWidth = 2.2;
-      canvasCtx.strokeStyle = "rgba(34, 211, 238, 0.9)";
+      canvasCtx.strokeStyle = "rgba(255,229,0,0.9)";
       for (let i = 0; i < timeDataArray.length; i += 1) {
         const x = (i / (timeDataArray.length - 1)) * width;
         const y = (timeDataArray[i] / 255) * height;
@@ -601,9 +601,9 @@
       const width = visualizer.width;
       const height = visualizer.height;
       canvasCtx.clearRect(0, 0, width, height);
-      canvasCtx.fillStyle = "rgba(4, 4, 12, 0.95)";
+      canvasCtx.fillStyle = "rgba(10, 10, 10, 0.97)";
       canvasCtx.fillRect(0, 0, width, height);
-      canvasCtx.strokeStyle = "rgba(139, 92, 246, 0.45)";
+      canvasCtx.strokeStyle = "rgba(255,229,0,0.55)";
       canvasCtx.lineWidth = 2;
       canvasCtx.beginPath();
       for (let x = 0; x <= width; x += 8) {

--- a/styles.css
+++ b/styles.css
@@ -1,113 +1,58 @@
 /* ══════════════════════════════════════════════════════════════
-   VOCA AI — SKEW MORPHISM + GLASSMORPHISM THEME
+   VOCA AI — NEW BRUTALIST THEME
+   Palette: Cream #F5F0E8 · Black #111 · Yellow #FFE500 · Blue #0047FF · Red #FF2400
    ══════════════════════════════════════════════════════════════ */
 
 :root {
-  /* Dark base */
-  --bg-void:    #040408;
-  --bg-deep:    #070710;
-  --bg-surface: #0c0c1a;
+  --bg:       #F5F0E8;
+  --black:    #111111;
+  --white:    #FFFFFF;
+  --yellow:   #FFE500;
+  --blue:     #0047FF;
+  --red:      #FF2400;
+  --green:    #00B050;
 
-  /* Glass */
-  --glass-bg:          rgba(255, 255, 255, 0.04);
-  --glass-bg-md:       rgba(255, 255, 255, 0.07);
-  --glass-bg-hover:    rgba(255, 255, 255, 0.09);
-  --glass-border:      rgba(255, 255, 255, 0.08);
-  --glass-border-hi:   rgba(255, 255, 255, 0.18);
+  --border:   3px solid var(--black);
+  --shadow:   5px 5px 0 var(--black);
+  --shadow-lg: 8px 8px 0 var(--black);
+  --shadow-blue: 5px 5px 0 var(--blue);
+  --shadow-yellow: 5px 5px 0 var(--yellow);
 
-  /* Accents */
-  --violet:   #8b5cf6;
-  --violet-lo: rgba(139, 92, 246, 0.15);
-  --cyan:     #22d3ee;
-  --cyan-lo:   rgba(34, 211, 238, 0.12);
-  --emerald:  #34d399;
-  --rose:     #f43f5e;
-  --amber:    #f59e0b;
-
-  /* Glow */
-  --glow-v:  rgba(139, 92, 246, 0.4);
-  --glow-c:  rgba(34, 211, 238, 0.4);
-  --glow-e:  rgba(52, 211, 153, 0.35);
-
-  /* Text */
-  --text-primary:   #f0f2ff;
-  --text-secondary: #8892b0;
-  --text-accent:    #c4b5fd;
-
-  /* Layout */
   --container: min(1140px, 92vw);
-  --r-sm: 8px;
-  --r-md: 14px;
-  --r-lg: 22px;
+  --r: 0px;
 }
 
 /* ── RESET ──────────────────────────────────────────────────── */
 *, *::before, *::after { box-sizing: border-box; }
-
 html { scroll-behavior: smooth; }
 
 body {
   margin: 0;
   min-height: 100vh;
-  background-color: var(--bg-void);
-  background-image:
-    radial-gradient(ellipse 80% 60% at 15% 40%, rgba(139, 92, 246, 0.12) 0%, transparent 60%),
-    radial-gradient(ellipse 70% 50% at 85% 10%, rgba(34, 211, 238, 0.09) 0%, transparent 55%),
-    radial-gradient(ellipse 60% 70% at 55% 90%, rgba(244, 63, 94, 0.06) 0%, transparent 55%);
-  color: var(--text-primary);
-  font-family: "Poppins", system-ui, sans-serif;
+  background-color: var(--bg);
+  color: var(--black);
+  font-family: "Space Grotesk", "Poppins", system-ui, sans-serif;
   line-height: 1.5;
   overflow-x: hidden;
 }
 
 a { color: inherit; text-decoration: none; }
-
 .container { width: var(--container); margin: 0 auto; }
 
-/* ── AMBIENT ORBS ────────────────────────────────────────────── */
-.ambient {
-  position: fixed;
-  border-radius: 50%;
-  filter: blur(80px);
-  pointer-events: none;
-  z-index: 0;
-  opacity: 0.18;
-}
-
-.ambient-a {
-  width: 600px; height: 600px;
-  background: radial-gradient(circle, #8b5cf6, transparent 70%);
-  top: -120px; left: -150px;
-}
-
-.ambient-b {
-  width: 500px; height: 500px;
-  background: radial-gradient(circle, #22d3ee, transparent 70%);
-  top: 40%; right: -100px;
-}
-
-.ambient-c {
-  width: 400px; height: 400px;
-  background: radial-gradient(circle, #f43f5e, transparent 70%);
-  bottom: 10%; left: 30%;
-}
+/* ── AMBIENT ORBS — hidden in brutalist style ────────────────── */
+.ambient { display: none; }
 
 /* ── HEADER ─────────────────────────────────────────────────── */
 .site-header {
   position: sticky;
   top: 0;
   z-index: 100;
-  background: rgba(7, 7, 16, 0.6);
-  backdrop-filter: blur(24px) saturate(180%);
-  -webkit-backdrop-filter: blur(24px) saturate(180%);
-  border-bottom: 1px solid var(--glass-border);
-  transition: border-color 0.3s, background 0.3s;
+  background: var(--yellow);
+  border-bottom: var(--border);
 }
 
 .site-header.scrolled {
-  background: rgba(7, 7, 16, 0.85);
-  border-bottom-color: rgba(139, 92, 246, 0.25);
-  box-shadow: 0 4px 40px rgba(0, 0, 0, 0.4);
+  box-shadow: 0 4px 0 var(--black);
 }
 
 .header-inner {
@@ -124,7 +69,7 @@ a { color: inherit; text-decoration: none; }
   flex-shrink: 0;
 }
 
-.brand-logo { width: 30px; height: 30px; }
+.brand-logo { width: 30px; height: 30px; filter: invert(1); }
 
 .brand-lockup {
   display: flex;
@@ -133,47 +78,44 @@ a { color: inherit; text-decoration: none; }
 }
 
 .brand-text {
-  font-size: 1rem;
-  font-weight: 800;
-  letter-spacing: 0.08em;
-  background: linear-gradient(135deg, #c4b5fd 0%, #22d3ee 100%);
-  -webkit-background-clip: text;
-  -webkit-text-fill-color: transparent;
-  background-clip: text;
+  font-size: 1.1rem;
+  font-weight: 900;
+  letter-spacing: 0.06em;
+  color: var(--black);
+  text-transform: uppercase;
 }
 
 .brand-sub {
   font-size: 0.52rem;
-  font-weight: 600;
+  font-weight: 700;
   text-transform: uppercase;
-  letter-spacing: 0.14em;
-  color: var(--text-secondary);
+  letter-spacing: 0.16em;
+  color: var(--black);
+  opacity: 0.6;
 }
 
 .site-nav {
   display: flex;
   align-items: center;
-  gap: 0.25rem;
+  gap: 0.2rem;
   margin-left: auto;
 }
 
 .site-nav a {
-  font-size: 0.75rem;
-  font-weight: 600;
+  font-size: 0.72rem;
+  font-weight: 800;
   text-transform: uppercase;
-  letter-spacing: 0.07em;
+  letter-spacing: 0.1em;
   padding: 0.4rem 0.75rem;
-  border-radius: var(--r-sm);
-  border: 1px solid transparent;
-  color: var(--text-secondary);
-  transition: color 0.2s, border-color 0.2s, background 0.2s;
+  border: 2px solid transparent;
+  color: var(--black);
+  transition: border-color 0.15s, background 0.15s;
 }
 
 .site-nav a:hover,
 .site-nav a.active {
-  color: var(--text-primary);
-  border-color: var(--glass-border-hi);
-  background: var(--glass-bg-md);
+  border-color: var(--black);
+  background: var(--white);
 }
 
 /* ── BUTTONS ─────────────────────────────────────────────────── */
@@ -181,105 +123,96 @@ a { color: inherit; text-decoration: none; }
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  font-family: "Poppins", system-ui, sans-serif;
-  font-weight: 700;
+  font-family: inherit;
+  font-weight: 800;
   font-size: 0.8rem;
   text-transform: uppercase;
-  letter-spacing: 0.07em;
+  letter-spacing: 0.1em;
   padding: 0.75rem 1.6rem;
-  border-radius: var(--r-md);
-  border: 1px solid var(--glass-border-hi);
+  border: var(--border);
   cursor: pointer;
-  background: var(--glass-bg-md);
-  color: var(--text-primary);
-  backdrop-filter: blur(12px);
-  -webkit-backdrop-filter: blur(12px);
-  transition: transform 0.2s, box-shadow 0.2s, background 0.2s, border-color 0.2s;
+  background: var(--white);
+  color: var(--black);
+  transition: transform 0.1s, box-shadow 0.1s;
   white-space: nowrap;
   position: relative;
-  overflow: hidden;
-}
-
-.btn::before {
-  content: "";
-  position: absolute;
-  inset: 0;
-  background: linear-gradient(135deg, rgba(255,255,255,0.06) 0%, transparent 60%);
-  pointer-events: none;
+  box-shadow: var(--shadow);
 }
 
 .btn:hover {
-  transform: translateY(-2px);
-  box-shadow: 0 8px 30px rgba(0, 0, 0, 0.35);
-  background: var(--glass-bg-hover);
+  transform: translate(-2px, -2px);
+  box-shadow: 7px 7px 0 var(--black);
 }
 
-.btn:active { transform: translateY(0); }
+.btn:active {
+  transform: translate(2px, 2px);
+  box-shadow: 2px 2px 0 var(--black);
+}
 
 .btn-primary {
-  background: linear-gradient(135deg, rgba(139, 92, 246, 0.7) 0%, rgba(99, 58, 220, 0.8) 100%);
-  border-color: rgba(167, 139, 250, 0.4);
-  box-shadow: 0 4px 20px var(--glow-v);
+  background: var(--yellow);
+  color: var(--black);
 }
 
 .btn-primary:hover {
-  background: linear-gradient(135deg, rgba(167, 139, 250, 0.8) 0%, rgba(139, 92, 246, 0.9) 100%);
-  box-shadow: 0 8px 40px var(--glow-v);
+  background: var(--yellow);
+  box-shadow: 7px 7px 0 var(--black);
 }
 
 .btn-outline {
-  background: transparent;
-  border-color: var(--glass-border-hi);
-  color: var(--text-accent);
+  background: var(--bg);
+  border-color: var(--black);
+  color: var(--black);
 }
 
 .btn-outline:hover {
-  border-color: rgba(196, 181, 253, 0.5);
-  box-shadow: 0 8px 30px rgba(139, 92, 246, 0.2);
+  background: var(--black);
+  color: var(--yellow);
 }
 
 .btn-small {
   padding: 0.45rem 1.1rem;
-  font-size: 0.72rem;
+  font-size: 0.7rem;
 }
 
-.header-cta { margin-left: 0.6rem; }
+.header-cta {
+  margin-left: 0.6rem;
+  background: var(--black);
+  color: var(--yellow);
+}
+
+.header-cta:hover {
+  background: var(--black);
+  color: var(--yellow);
+  box-shadow: 7px 7px 0 rgba(0,0,0,0.3);
+}
 
 /* ── TYPOGRAPHY ─────────────────────────────────────────────── */
 h1, h2, h3 {
-  font-weight: 800;
-  line-height: 1.1;
+  font-weight: 900;
+  line-height: 1.05;
   margin: 0 0 0.75rem;
   letter-spacing: -0.02em;
+  text-transform: uppercase;
 }
 
-h1 { font-size: clamp(2.4rem, 5.5vw, 4rem); }
-h2 { font-size: clamp(1.7rem, 3.5vw, 2.6rem); }
-h3 { font-size: 1.05rem; font-weight: 700; letter-spacing: -0.01em; }
+h1 { font-size: clamp(2.6rem, 6vw, 4.5rem); }
+h2 { font-size: clamp(1.8rem, 3.8vw, 2.8rem); }
+h3 { font-size: 1.05rem; font-weight: 800; letter-spacing: 0em; }
 
 p { margin: 0 0 1rem; }
 
 .eyebrow {
-  font-size: 0.68rem;
-  font-weight: 700;
+  font-size: 0.65rem;
+  font-weight: 800;
   text-transform: uppercase;
-  letter-spacing: 0.16em;
-  background: linear-gradient(135deg, var(--violet), var(--cyan));
-  -webkit-background-clip: text;
-  -webkit-text-fill-color: transparent;
-  background-clip: text;
+  letter-spacing: 0.2em;
+  color: var(--black);
   display: inline-block;
   margin-bottom: 0.75rem;
-  position: relative;
-}
-
-.eyebrow::after {
-  content: "";
-  display: block;
-  height: 1px;
-  background: linear-gradient(90deg, var(--violet), var(--cyan), transparent);
-  margin-top: 4px;
-  opacity: 0.5;
+  background: var(--yellow);
+  padding: 0.2rem 0.6rem;
+  border: 2px solid var(--black);
 }
 
 /* ── SECTION ─────────────────────────────────────────────────── */
@@ -291,57 +224,54 @@ p { margin: 0 0 1rem; }
 
 .section-head {
   text-align: center;
-  max-width: 680px;
+  max-width: 700px;
   margin: 0 auto 4rem;
 }
 
 .section-head p:not(.eyebrow) {
-  font-size: 0.92rem;
-  color: var(--text-secondary);
-  line-height: 1.7;
-}
-
-/* Skewed section dividers */
-.section::before {
-  content: none;
-}
-
-/* Alternating skew backgrounds */
-.section:nth-child(even) {
-  background: transparent;
+  font-size: 0.95rem;
+  color: var(--black);
+  opacity: 0.7;
 }
 
 /* ── HERO ─────────────────────────────────────────────────────── */
 .hero {
-  padding: 120px 0 100px;
-  position: relative;
-  overflow: hidden;
-}
-
-.hero::before {
-  content: "";
-  position: absolute;
-  inset: 0;
-  background: linear-gradient(135deg,
-    rgba(139, 92, 246, 0.07) 0%,
-    rgba(34, 211, 238, 0.04) 50%,
-    transparent 100%);
-  pointer-events: none;
+  background: var(--black);
+  color: var(--white);
+  padding: 80px 0 80px;
+  border-bottom: var(--border);
 }
 
 .hero-grid {
   display: grid;
   grid-template-columns: 1fr 1fr;
-  gap: 4rem;
-  align-items: start;
-  position: relative;
+  gap: 3rem;
+  align-items: center;
 }
 
-[data-hero-stagger] {
-  opacity: 0;
-  transform: translateY(20px);
+.hero-copy .eyebrow {
+  background: var(--yellow);
+  color: var(--black);
 }
 
+.hero-copy h1 {
+  color: var(--white);
+  line-height: 1;
+  margin-bottom: 1rem;
+}
+
+.hero-copy h1 em {
+  font-style: normal;
+  color: var(--yellow);
+}
+
+.hero-subtitle {
+  font-size: 1rem;
+  color: rgba(255,255,255,0.75);
+  max-width: 500px;
+}
+
+/* Hero kicker pills */
 .hero-kicker-row {
   display: flex;
   gap: 0.5rem;
@@ -350,187 +280,125 @@ p { margin: 0 0 1rem; }
 }
 
 .hero-kicker-pill {
-  font-size: 0.68rem;
-  font-weight: 700;
+  font-size: 0.7rem;
+  font-weight: 800;
   text-transform: uppercase;
-  letter-spacing: 0.1em;
-  padding: 0.3rem 0.8rem;
-  border-radius: 100px;
-  border: 1px solid rgba(139, 92, 246, 0.4);
-  background: rgba(139, 92, 246, 0.12);
-  color: #c4b5fd;
-  backdrop-filter: blur(8px);
+  letter-spacing: 0.12em;
+  padding: 0.3rem 0.75rem;
+  background: var(--yellow);
+  color: var(--black);
+  border: 2px solid var(--yellow);
 }
 
-.hero-title {
-  font-size: clamp(2.5rem, 5.5vw, 4.4rem);
-  font-weight: 900;
-  line-height: 1.05;
-  margin-bottom: 1.2rem;
-  letter-spacing: -0.03em;
-  background: linear-gradient(160deg, #ffffff 0%, #c4b5fd 50%, #22d3ee 100%);
-  -webkit-background-clip: text;
-  -webkit-text-fill-color: transparent;
-  background-clip: text;
-}
-
-.hero-subtitle {
-  font-size: 1rem;
-  font-weight: 400;
-  color: var(--text-secondary);
-  margin-bottom: 1.75rem;
-  line-height: 1.7;
-}
-
+/* Hero proof items */
 .hero-proof {
   display: grid;
   grid-template-columns: 1fr 1fr;
   gap: 1rem;
-  margin-bottom: 1.75rem;
+  margin: 1.5rem 0;
 }
 
 .hero-proof-item {
-  padding: 1.1rem 1.2rem;
-  border-radius: var(--r-md);
-  border: 1px solid var(--glass-border);
-  background: var(--glass-bg);
-  backdrop-filter: blur(16px);
-  -webkit-backdrop-filter: blur(16px);
-  transition: border-color 0.2s, background 0.2s;
-}
-
-.hero-proof-item:hover {
-  border-color: rgba(139, 92, 246, 0.3);
-  background: var(--glass-bg-md);
+  background: rgba(255,255,255,0.05);
+  border: 2px solid rgba(255,255,255,0.15);
+  padding: 1rem;
 }
 
 .hero-proof-title {
   font-size: 0.75rem;
-  font-weight: 700;
+  font-weight: 800;
   text-transform: uppercase;
-  letter-spacing: 0.05em;
-  margin-bottom: 0.35rem;
-  padding-bottom: 0.35rem;
-  border-bottom: 1px solid rgba(139, 92, 246, 0.3);
-  color: var(--text-accent);
+  letter-spacing: 0.08em;
+  color: var(--yellow);
+  margin-bottom: 0.4rem;
 }
 
 .hero-proof-copy {
   font-size: 0.78rem;
-  color: var(--text-secondary);
+  color: rgba(255,255,255,0.65);
   margin: 0;
-  line-height: 1.55;
 }
 
+/* Hero CTA */
 .hero-cta {
   display: flex;
-  gap: 0.85rem;
+  gap: 1rem;
   flex-wrap: wrap;
-  margin-bottom: 2rem;
+  margin-top: 1.5rem;
 }
 
+/* Hero Metrics */
 .hero-metrics {
   display: flex;
-  gap: 0.75rem;
+  gap: 1rem;
   flex-wrap: wrap;
+  margin-top: 2rem;
+  border-top: 2px solid rgba(255,255,255,0.15);
+  padding-top: 1.5rem;
 }
 
 .metric-chip {
   display: flex;
   flex-direction: column;
-  padding: 0.85rem 1.1rem;
-  border-radius: var(--r-md);
-  border: 1px solid rgba(34, 211, 238, 0.2);
-  background: rgba(34, 211, 238, 0.05);
-  backdrop-filter: blur(12px);
-  min-width: 120px;
-  transition: border-color 0.2s, box-shadow 0.2s;
-}
-
-.metric-chip:hover {
-  border-color: rgba(34, 211, 238, 0.4);
-  box-shadow: 0 0 20px rgba(34, 211, 238, 0.15);
+  gap: 0.2rem;
 }
 
 .metric-value {
-  font-size: 1.85rem;
+  font-size: 2.2rem;
   font-weight: 900;
+  color: var(--yellow);
   line-height: 1;
-  letter-spacing: -0.03em;
-  background: linear-gradient(135deg, var(--cyan), var(--emerald));
-  -webkit-background-clip: text;
-  -webkit-text-fill-color: transparent;
-  background-clip: text;
 }
+
+.metric-value::after { content: "+"; }
 
 .metric-label {
-  font-size: 0.62rem;
-  font-weight: 500;
-  color: var(--text-secondary);
-  margin-top: 0.25rem;
-  line-height: 1.3;
-}
-
-/* Hero visual */
-.hero-visual { position: relative; }
-
-.hero-floating {
-  position: absolute;
   font-size: 0.65rem;
   font-weight: 700;
   text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: rgba(255,255,255,0.55);
+  max-width: 100px;
+}
+
+/* Hero Visual */
+.hero-visual {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.hero-floating {
+  font-size: 0.72rem;
+  font-weight: 800;
+  text-transform: uppercase;
   letter-spacing: 0.1em;
-  padding: 0.4rem 0.75rem;
-  border-radius: 100px;
-  z-index: 2;
-  white-space: nowrap;
-  backdrop-filter: blur(16px);
-  border: 1px solid;
+  padding: 0.5rem 1rem;
+  border: 2px solid var(--yellow);
+  background: var(--yellow);
+  color: var(--black);
+  width: fit-content;
 }
 
-.hero-floating-a {
-  top: 6%;
-  left: -5%;
-  border-color: rgba(52, 211, 153, 0.4);
-  background: rgba(52, 211, 153, 0.12);
-  color: var(--emerald);
-  box-shadow: 0 0 20px rgba(52, 211, 153, 0.2);
-}
+.hero-floating-a { align-self: flex-start; }
+.hero-floating-b { align-self: flex-end; }
 
-.hero-floating-b {
-  bottom: 12%;
-  right: -3%;
-  border-color: rgba(34, 211, 238, 0.4);
-  background: rgba(34, 211, 238, 0.1);
-  color: var(--cyan);
-  box-shadow: 0 0 20px rgba(34, 211, 238, 0.2);
-}
-
-#hero-wave {
-  width: 100%;
-  display: block;
-  border-radius: var(--r-lg) var(--r-lg) 0 0;
-  border: 1px solid var(--glass-border);
-}
+#hero-wave { display: none; }
 
 .hero-glass {
-  border: 1px solid var(--glass-border);
-  border-top: none;
-  background: rgba(12, 12, 26, 0.75);
-  backdrop-filter: blur(24px);
-  -webkit-backdrop-filter: blur(24px);
-  padding: 1.25rem 1.4rem;
-  border-radius: 0 0 var(--r-lg) var(--r-lg);
+  background: rgba(255, 255, 255, 0.06);
+  border: 2px solid rgba(255,255,255,0.2);
+  padding: 1.25rem;
 }
 
 .glass-label {
   font-size: 0.65rem;
-  font-weight: 700;
+  font-weight: 800;
   text-transform: uppercase;
-  letter-spacing: 0.14em;
+  letter-spacing: 0.15em;
+  color: var(--yellow);
   margin-bottom: 0.75rem;
-  color: var(--cyan);
-  opacity: 0.85;
 }
 
 .live-feed {
@@ -539,632 +407,378 @@ p { margin: 0 0 1rem; }
   padding: 0;
   display: flex;
   flex-direction: column;
-  gap: 0.45rem;
-  font-size: 0.78rem;
-  font-weight: 500;
-  color: var(--text-secondary);
+  gap: 0.5rem;
+  font-size: 0.82rem;
+  color: rgba(255,255,255,0.8);
 }
-
-.live-feed li {
-  display: flex;
-  align-items: center;
-  gap: 0.55rem;
-  padding: 0.4rem 0.6rem;
-  border-radius: var(--r-sm);
-  border: 1px solid var(--glass-border);
-  background: var(--glass-bg);
-  transition: background 0.2s;
-}
-
-.live-feed li:hover { background: var(--glass-bg-md); }
 
 .feed-pill {
   font-size: 0.6rem;
-  font-weight: 700;
+  font-weight: 800;
   text-transform: uppercase;
-  letter-spacing: 0.08em;
-  padding: 0.12rem 0.45rem;
-  border-radius: 100px;
-  white-space: nowrap;
-  flex-shrink: 0;
-  border: 1px solid transparent;
+  letter-spacing: 0.1em;
+  padding: 0.15rem 0.5rem;
+  margin-right: 0.4rem;
+  border: 1.5px solid;
 }
 
-.intent-hot {
-  background: rgba(244, 63, 94, 0.15);
-  color: #fb7185;
-  border-color: rgba(244, 63, 94, 0.3);
-}
-.intent-mid {
-  background: rgba(34, 211, 238, 0.12);
-  color: var(--cyan);
-  border-color: rgba(34, 211, 238, 0.3);
-}
-.intent-save {
-  background: rgba(52, 211, 153, 0.12);
-  color: var(--emerald);
-  border-color: rgba(52, 211, 153, 0.3);
-}
+.intent-hot  { background: var(--red);    color: var(--white); border-color: var(--red); }
+.intent-mid  { background: var(--blue);   color: var(--white); border-color: var(--blue); }
+.intent-save { background: var(--green);  color: var(--white); border-color: var(--green); }
 
-/* ── WAVE DIVIDERS ─────────────────────────────────────────── */
-.wave-divider {
-  background: transparent;
-  border-top: 1px solid var(--glass-border);
-  border-bottom: 1px solid var(--glass-border);
-  height: 100px;
-  overflow: hidden;
-  display: flex;
-  align-items: center;
-  position: relative;
-}
-
-.wave-divider::before {
-  content: "";
-  position: absolute;
-  inset: 0;
-  background: linear-gradient(180deg, rgba(139, 92, 246, 0.04) 0%, rgba(34, 211, 238, 0.04) 100%);
-}
-
-.wave-divider-canvas { width: 100%; display: block; }
-
-.wave-panel {
-  background: rgba(0, 0, 0, 0.3);
-  border: 1px solid var(--glass-border);
-  border-radius: var(--r-md);
-  display: block;
-  width: 100%;
-  margin-bottom: 2.5rem;
-  overflow: hidden;
-}
-
-/* ── SKEW SECTION BACKGROUNDS ────────────────────────────────── */
-.legacy,
-.guardrails,
-.voice-demo {
-  position: relative;
-}
-
-.legacy::before,
-.guardrails::before {
-  content: "";
-  position: absolute;
-  inset: -4% 0;
-  background: linear-gradient(160deg, rgba(139, 92, 246, 0.04) 0%, rgba(34, 211, 238, 0.03) 100%);
-  transform: skewY(-2deg);
-  z-index: -1;
-  border-top: 1px solid rgba(139, 92, 246, 0.08);
-  border-bottom: 1px solid rgba(34, 211, 238, 0.08);
-}
-
-.voice-demo::before {
-  content: "";
-  position: absolute;
-  inset: -4% 0;
-  background: linear-gradient(160deg, rgba(34, 211, 238, 0.04) 0%, rgba(139, 92, 246, 0.03) 100%);
-  transform: skewY(2deg);
-  z-index: -1;
-  border-top: 1px solid rgba(34, 211, 238, 0.08);
-  border-bottom: 1px solid rgba(139, 92, 246, 0.08);
-}
+/* ── WAVE DIVIDERS — replaced with solid stripe ────────────────── */
+.wave-divider { display: none; }
+.wave-divider-canvas { display: none; }
+.wave-panel { display: none; }
 
 /* ── PAIN GRID ─────────────────────────────────────────────── */
 .pain-grid {
   display: grid;
-  grid-template-columns: repeat(4, 1fr);
-  gap: 1.25rem;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 1.5rem;
 }
 
 .pain-card {
-  padding: 1.5rem;
-  border-radius: var(--r-md);
-  border: 1px solid var(--glass-border);
-  background: var(--glass-bg);
-  backdrop-filter: blur(16px);
-  -webkit-backdrop-filter: blur(16px);
-  transition: transform 0.25s, box-shadow 0.25s, border-color 0.25s, background 0.25s;
-  position: relative;
-  overflow: hidden;
-}
-
-.pain-card::before {
-  content: "";
-  position: absolute;
-  top: 0; left: 0; right: 0;
-  height: 2px;
-  background: linear-gradient(90deg, var(--violet), var(--cyan));
-  opacity: 0;
-  transition: opacity 0.25s;
+  background: var(--white);
+  border: var(--border);
+  box-shadow: var(--shadow);
+  padding: 1.75rem 1.5rem;
+  transition: transform 0.1s, box-shadow 0.1s;
 }
 
 .pain-card:hover {
-  transform: translateY(-4px) skewY(-0.5deg);
-  box-shadow: 0 12px 40px rgba(0, 0, 0, 0.4), 0 0 30px var(--glow-v);
-  border-color: rgba(139, 92, 246, 0.25);
-  background: var(--glass-bg-md);
+  transform: translate(-3px, -3px);
+  box-shadow: var(--shadow-lg);
 }
 
-.pain-card:hover::before { opacity: 1; }
-
 .pain-card h3 {
-  font-size: 0.85rem;
-  font-weight: 700;
+  font-size: 0.9rem;
+  margin-bottom: 0.6rem;
   text-transform: uppercase;
-  letter-spacing: 0.04em;
-  margin-bottom: 0.55rem;
-  padding-bottom: 0.45rem;
-  border-bottom: 1px solid rgba(139, 92, 246, 0.25);
-  color: var(--text-accent);
+  letter-spacing: 0.06em;
 }
 
 .pain-card p {
-  font-size: 0.8rem;
-  color: var(--text-secondary);
+  font-size: 0.82rem;
+  opacity: 0.7;
   margin: 0;
-  line-height: 1.55;
 }
 
-/* ── LEGACY ─────────────────────────────────────────────────── */
+.pain-icon {
+  font-size: 1.5rem;
+  margin-bottom: 0.75rem;
+  display: block;
+  width: 44px;
+  height: 44px;
+  background: var(--yellow);
+  border: 2px solid var(--black);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+/* ── LEGACY SECTION ─────────────────────────────────────────── */
+.legacy { background: var(--black); color: var(--white); }
+.legacy .eyebrow { background: var(--red); color: var(--white); border-color: var(--red); }
+.legacy .section-head h2 { color: var(--white); }
+
 .legacy-shell {
   display: grid;
   grid-template-columns: 1fr 1fr;
-  border-radius: var(--r-lg);
-  border: 1px solid var(--glass-border);
-  overflow: hidden;
-  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.5);
+  gap: 2rem;
 }
 
-.legacy-panel { padding: 2.25rem; }
+.legacy-panel {
+  padding: 2rem;
+  border: 2px solid rgba(255,255,255,0.2);
+}
 
 .legacy-before {
-  background: rgba(20, 20, 35, 0.6);
-  border-right: 1px solid var(--glass-border);
-  backdrop-filter: blur(16px);
+  background: rgba(255,255,255,0.03);
 }
 
 .legacy-after {
-  background: linear-gradient(160deg, rgba(139, 92, 246, 0.12) 0%, rgba(34, 211, 238, 0.06) 100%);
-  backdrop-filter: blur(16px);
+  background: var(--yellow);
+  color: var(--black);
+  border-color: var(--yellow);
 }
 
 .legacy-panel h3 {
-  font-size: 0.78rem;
-  font-weight: 700;
+  font-size: 0.8rem;
   text-transform: uppercase;
-  letter-spacing: 0.1em;
-  margin-bottom: 1.4rem;
-  padding-bottom: 0.55rem;
+  letter-spacing: 0.15em;
+  margin-bottom: 1.25rem;
+  padding-bottom: 0.75rem;
+  border-bottom: 2px solid currentColor;
+  opacity: 0.6;
 }
 
-.legacy-before h3 {
-  border-bottom: 1px solid var(--glass-border);
-  color: var(--text-secondary);
-}
-
-.legacy-after h3 {
-  border-bottom: 1px solid rgba(139, 92, 246, 0.35);
-  background: linear-gradient(135deg, #c4b5fd, var(--cyan));
-  -webkit-background-clip: text;
-  -webkit-text-fill-color: transparent;
-  background-clip: text;
-}
+.legacy-after h3 { opacity: 1; }
 
 .legacy-panel ul {
   list-style: none;
-  margin: 0;
   padding: 0;
+  margin: 0;
   display: flex;
   flex-direction: column;
-  gap: 0.7rem;
+  gap: 0.75rem;
 }
 
-.legacy-panel li {
-  font-size: 0.84rem;
-  font-weight: 400;
-  padding: 0.45rem 0.6rem 0.45rem 1.6rem;
+.legacy-panel ul li {
+  font-size: 0.88rem;
+  font-weight: 600;
+  padding-left: 1.2rem;
   position: relative;
-  border-radius: var(--r-sm);
-  border: 1px solid transparent;
 }
 
-.legacy-before li {
-  background: rgba(0, 0, 0, 0.25);
-  border-color: var(--glass-border);
-  color: var(--text-secondary);
-}
-
-.legacy-after li {
-  background: rgba(139, 92, 246, 0.08);
-  border-color: rgba(139, 92, 246, 0.2);
-  color: var(--text-primary);
-}
-
-.legacy-before li::before {
-  content: "✕";
+.legacy-panel ul li::before {
+  content: "—";
   position: absolute;
-  left: 0.5rem;
+  left: 0;
   font-weight: 900;
-  color: #f43f5e;
-  font-size: 0.7rem;
 }
 
-.legacy-after li::before {
-  content: "→";
-  position: absolute;
-  left: 0.5rem;
-  font-weight: 700;
-  color: var(--violet);
-}
+.legacy-before ul li { color: rgba(255,255,255,0.55); }
+.legacy-after ul li::before { content: "→"; }
 
-/* ── PRODUCT CARDS ─────────────────────────────────────────── */
+/* ── PRODUCT GRID ─────────────────────────────────────────── */
 .product-grid {
   display: grid;
   grid-template-columns: 1fr 1fr;
-  gap: 1.75rem;
+  gap: 2rem;
 }
 
 .product-card {
-  border-radius: var(--r-lg);
-  border: 1px solid var(--glass-border);
-  background: var(--glass-bg);
-  backdrop-filter: blur(20px);
-  -webkit-backdrop-filter: blur(20px);
-  transition: transform 0.25s, box-shadow 0.25s, border-color 0.25s;
-  overflow: hidden;
-  position: relative;
+  background: var(--white);
+  border: var(--border);
+  box-shadow: var(--shadow-lg);
+  padding: 2rem;
+  transition: transform 0.1s, box-shadow 0.1s;
 }
 
-.product-card::before {
-  content: "";
-  position: absolute;
-  top: 0; left: 0; right: 0;
-  height: 1px;
-  background: linear-gradient(90deg, transparent, rgba(139, 92, 246, 0.6), rgba(34, 211, 238, 0.6), transparent);
+.product-card:nth-child(2) {
+  background: var(--black);
+  color: var(--white);
 }
 
 .product-card:hover {
-  transform: translateY(-6px) skewY(-0.3deg);
-  box-shadow: 0 24px 60px rgba(0, 0, 0, 0.5), 0 0 40px var(--glow-v);
-  border-color: rgba(139, 92, 246, 0.3);
+  transform: translate(-3px, -3px);
+  box-shadow: 11px 11px 0 var(--black);
 }
 
-.product-card-inner { padding: 2.25rem; }
+.product-card:nth-child(2):hover {
+  box-shadow: 11px 11px 0 var(--yellow);
+}
 
 .product-tag {
-  font-size: 0.62rem;
-  font-weight: 700;
+  font-size: 0.6rem;
+  font-weight: 800;
   text-transform: uppercase;
-  letter-spacing: 0.1em;
-  padding: 0.22rem 0.65rem;
-  border-radius: 100px;
-  border: 1px solid rgba(34, 211, 238, 0.35);
-  background: rgba(34, 211, 238, 0.1);
-  color: var(--cyan);
+  letter-spacing: 0.15em;
+  background: var(--yellow);
+  color: var(--black);
+  padding: 0.2rem 0.5rem;
+  border: 2px solid var(--black);
   display: inline-block;
   margin-bottom: 1rem;
 }
 
+.product-card:nth-child(2) .product-tag {
+  background: var(--blue);
+  color: var(--white);
+  border-color: var(--blue);
+}
+
 .product-card h3 {
-  font-size: 1.5rem;
-  font-weight: 800;
-  margin-bottom: 0.7rem;
-  background: linear-gradient(135deg, var(--text-primary), var(--text-accent));
-  -webkit-background-clip: text;
-  -webkit-text-fill-color: transparent;
-  background-clip: text;
+  font-size: 1.4rem;
+  font-weight: 900;
+  text-transform: uppercase;
+  letter-spacing: -0.01em;
+  margin-bottom: 0.75rem;
 }
 
 .product-card p {
   font-size: 0.85rem;
-  color: var(--text-secondary);
-  margin-bottom: 1.2rem;
-  line-height: 1.65;
+  opacity: 0.75;
 }
 
 .product-card ul {
   list-style: none;
-  margin: 0;
   padding: 0;
+  margin: 1rem 0 0;
   display: flex;
   flex-direction: column;
   gap: 0.5rem;
-  border-top: 1px solid var(--glass-border);
-  padding-top: 1.1rem;
 }
 
-.product-card li {
-  font-size: 0.78rem;
-  font-weight: 500;
-  padding: 0.4rem 0.6rem 0.4rem 1.4rem;
+.product-card ul li {
+  font-size: 0.8rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  padding-left: 1.2rem;
   position: relative;
-  border-radius: var(--r-sm);
-  border-left: 2px solid rgba(139, 92, 246, 0.5);
-  background: rgba(139, 92, 246, 0.06);
-  color: var(--text-secondary);
-  transition: background 0.2s, color 0.2s;
 }
 
-.product-card li:hover {
-  background: rgba(139, 92, 246, 0.12);
-  color: var(--text-primary);
-}
-
-.product-card li::before {
+.product-card ul li::before {
   content: "→";
   position: absolute;
-  left: 0.3rem;
-  font-weight: 700;
-  font-size: 0.65rem;
-  color: var(--violet);
+  left: 0;
+  font-weight: 900;
+  color: var(--yellow);
 }
 
-/* ── PRODUCT DETAILS ─────────────────────────────────────────── */
-.assist-detail,
-.voice-detail { background: transparent; }
+.product-card:nth-child(1) ul li::before { color: var(--blue); }
+
+/* ── PRODUCT DETAIL SECTIONS ─────────────────────────────── */
+.assist-detail { background: var(--white); }
+.voice-detail  { background: var(--yellow); }
 
 .detail-grid {
   display: grid;
   grid-template-columns: 1fr 1fr;
-  gap: 3.5rem;
-  align-items: start;
+  gap: 4rem;
+  align-items: center;
 }
 
+.detail-copy .eyebrow { }
+
 .detail-copy p:not(.eyebrow) {
-  font-size: 0.875rem;
-  color: var(--text-secondary);
-  line-height: 1.7;
-  margin-bottom: 1.3rem;
+  font-size: 0.92rem;
+  opacity: 0.75;
 }
 
 .feature-list {
   list-style: none;
-  margin: 0;
   padding: 0;
+  margin: 1.25rem 0 0;
   display: flex;
   flex-direction: column;
-  gap: 0.5rem;
+  gap: 0.6rem;
 }
 
 .feature-list li {
   font-size: 0.82rem;
-  font-weight: 500;
-  padding: 0.6rem 0.85rem 0.6rem 1.5rem;
-  position: relative;
-  border-radius: var(--r-sm);
-  border: 1px solid var(--glass-border);
-  border-left: 2px solid rgba(139, 92, 246, 0.5);
-  background: var(--glass-bg);
-  color: var(--text-secondary);
-  backdrop-filter: blur(8px);
-  transition: background 0.2s, color 0.2s, border-color 0.2s;
+  font-weight: 600;
+  padding: 0.6rem 0.75rem;
+  border-left: 4px solid var(--yellow);
+  background: rgba(0,0,0,0.03);
 }
 
-.feature-list li::before {
-  content: "→";
-  position: absolute;
-  left: 0.35rem;
-  font-weight: 700;
-  font-size: 0.7rem;
-  color: var(--violet);
-}
-
-.feature-list li:hover {
-  background: rgba(139, 92, 246, 0.1);
-  color: var(--text-primary);
-  border-color: rgba(139, 92, 246, 0.25);
-  border-left-color: var(--violet);
+.voice-detail .feature-list li {
+  border-left-color: var(--black);
+  background: rgba(0,0,0,0.06);
 }
 
 .detail-card {
-  border-radius: var(--r-lg);
-  border: 1px solid var(--glass-border);
-  background: var(--glass-bg-md);
-  backdrop-filter: blur(24px);
-  -webkit-backdrop-filter: blur(24px);
+  background: var(--black);
+  color: var(--white);
+  border: var(--border);
+  box-shadow: var(--shadow-lg);
   padding: 2rem;
-  box-shadow: 0 20px 50px rgba(0, 0, 0, 0.35);
-  position: relative;
-  overflow: hidden;
 }
 
-.detail-card::before {
-  content: "";
-  position: absolute;
-  top: 0; left: 0; right: 0;
-  height: 1px;
-  background: linear-gradient(90deg, transparent, rgba(139, 92, 246, 0.6), rgba(34, 211, 238, 0.6), transparent);
+.voice-detail .detail-card {
+  background: var(--white);
+  color: var(--black);
 }
 
 .detail-card h3 {
-  font-size: 0.75rem;
-  font-weight: 700;
+  font-size: 0.8rem;
   text-transform: uppercase;
-  letter-spacing: 0.14em;
+  letter-spacing: 0.15em;
+  opacity: 0.5;
   margin-bottom: 1.5rem;
-  padding-bottom: 0.65rem;
-  border-bottom: 1px solid var(--glass-border);
-  color: var(--text-accent);
+  padding-bottom: 0.75rem;
+  border-bottom: 2px solid currentColor;
 }
 
 /* Signal meters */
 .signal-item {
   display: flex;
-  flex-direction: column;
-  gap: 0.4rem;
-  margin-bottom: 1.2rem;
+  align-items: center;
+  gap: 1rem;
+  margin-bottom: 1rem;
 }
 
 .signal-item span {
-  font-size: 0.72rem;
-  font-weight: 600;
+  font-size: 0.75rem;
+  font-weight: 700;
   text-transform: uppercase;
   letter-spacing: 0.06em;
-  color: var(--text-secondary);
+  width: 160px;
+  flex-shrink: 0;
+  opacity: 0.8;
 }
 
 .signal-meter {
-  height: 6px;
-  background: rgba(255, 255, 255, 0.05);
-  border-radius: 100px;
+  flex: 1;
+  height: 12px;
+  background: rgba(255,255,255,0.1);
+  border: 2px solid rgba(255,255,255,0.2);
+  position: relative;
   overflow: hidden;
-  border: none;
 }
 
 .signal-meter i {
   display: block;
   height: 100%;
   width: var(--w, 0%);
-  background: linear-gradient(90deg, var(--violet), var(--cyan));
-  border-radius: 100px;
-  transition: width 1.2s ease;
-  box-shadow: 0 0 8px rgba(139, 92, 246, 0.5);
+  background: var(--yellow);
+  font-style: normal;
 }
 
 /* Workflow list */
 .workflow-list {
-  margin: 0;
   padding: 0;
+  margin: 0;
   list-style: none;
-  counter-reset: wstep;
+  counter-reset: step;
   display: flex;
   flex-direction: column;
-  gap: 0.6rem;
+  gap: 0.75rem;
 }
 
 .workflow-list li {
-  font-size: 0.84rem;
-  font-weight: 500;
-  padding: 0.75rem 0.9rem 0.75rem 3.4rem;
-  border-radius: var(--r-sm);
-  border: 1px solid var(--glass-border);
-  background: var(--glass-bg);
+  counter-increment: step;
+  font-size: 0.85rem;
+  font-weight: 600;
+  padding: 0.75rem 1rem 0.75rem 3rem;
+  background: rgba(0,0,0,0.04);
+  border: 2px solid var(--black);
   position: relative;
-  counter-increment: wstep;
-  color: var(--text-secondary);
-  backdrop-filter: blur(8px);
-  transition: background 0.2s, color 0.2s, border-color 0.2s;
-}
-
-.workflow-list li:hover {
-  background: rgba(139, 92, 246, 0.08);
-  color: var(--text-primary);
-  border-color: rgba(139, 92, 246, 0.2);
 }
 
 .workflow-list li::before {
-  content: counter(wstep, decimal-leading-zero);
+  content: counter(step);
   position: absolute;
   left: 0;
   top: 0;
   bottom: 0;
-  width: 2.6rem;
+  width: 2.5rem;
   display: flex;
   align-items: center;
   justify-content: center;
-  background: linear-gradient(180deg, rgba(139, 92, 246, 0.2), rgba(34, 211, 238, 0.1));
-  color: var(--cyan);
-  font-size: 0.72rem;
-  font-weight: 800;
-  letter-spacing: -0.01em;
-  border-right: 1px solid var(--glass-border);
-  border-radius: var(--r-sm) 0 0 var(--r-sm);
+  background: var(--black);
+  color: var(--yellow);
+  font-size: 0.8rem;
+  font-weight: 900;
 }
 
-/* ── ASSIST LOOP ─────────────────────────────────────────────── */
-.assist-loop { background: transparent; }
-
-.assist-loop-grid {
-  display: grid;
-  grid-template-columns: repeat(3, 1fr);
-  gap: 1.25rem;
-}
-
-.assist-loop-card {
-  border-radius: var(--r-md);
-  border: 1px solid var(--glass-border);
-  background: var(--glass-bg);
-  backdrop-filter: blur(16px);
-  -webkit-backdrop-filter: blur(16px);
-  padding: 1.5rem;
-  transition: transform 0.25s, box-shadow 0.25s, border-color 0.25s, background 0.25s;
-  position: relative;
-  overflow: hidden;
-}
-
-.assist-loop-card::after {
-  content: "";
-  position: absolute;
-  bottom: 0; left: 0; right: 0;
-  height: 1px;
-  background: linear-gradient(90deg, transparent, rgba(244, 63, 94, 0.5), transparent);
-  opacity: 0;
-  transition: opacity 0.25s;
-}
-
-.assist-loop-card:hover {
-  transform: translateY(-4px) skewY(-0.3deg);
-  box-shadow: 0 12px 40px rgba(0, 0, 0, 0.4);
-  border-color: rgba(244, 63, 94, 0.2);
-  background: var(--glass-bg-md);
-}
-
-.assist-loop-card:hover::after { opacity: 1; }
-
-.assist-kicker {
-  font-size: 0.6rem;
-  font-weight: 700;
-  text-transform: uppercase;
-  letter-spacing: 0.12em;
-  padding: 0.2rem 0.55rem;
-  border-radius: 100px;
-  border: 1px solid rgba(244, 63, 94, 0.3);
-  background: rgba(244, 63, 94, 0.1);
-  color: #fb7185;
-  display: inline-block;
-  margin-bottom: 0.75rem;
-}
-
-.assist-loop-card h3 {
-  font-size: 0.85rem;
-  font-weight: 700;
-  margin-bottom: 0.4rem;
-  color: var(--text-primary);
-}
-
-.assist-loop-card p {
-  font-size: 0.78rem;
-  color: var(--text-secondary);
-  margin-bottom: 0.75rem;
-  line-height: 1.55;
-}
-
-.assist-metric {
-  font-size: 0.68rem;
-  font-weight: 600;
-  padding: 0.35rem 0.65rem;
-  border-radius: var(--r-sm);
-  background: rgba(139, 92, 246, 0.1);
-  border: 1px solid rgba(139, 92, 246, 0.25);
-  color: var(--text-accent);
-  display: inline-block;
-}
-
-/* ── LANGUAGE ─────────────────────────────────────────────── */
+/* Language block */
 .language-block {
   margin-top: 1.5rem;
-  border-radius: var(--r-md);
-  border: 1px solid var(--glass-border);
-  padding: 1.4rem;
-  background: var(--glass-bg);
-  backdrop-filter: blur(12px);
+  border-top: 2px solid var(--black);
+  padding-top: 1.25rem;
 }
 
 .language-title {
   font-size: 0.65rem;
-  font-weight: 700;
+  font-weight: 800;
   text-transform: uppercase;
-  letter-spacing: 0.12em;
+  letter-spacing: 0.15em;
   margin-bottom: 0.75rem;
-  color: var(--text-secondary);
+  opacity: 0.6;
 }
 
 .language-cloud {
@@ -1173,144 +787,152 @@ p { margin: 0 0 1rem; }
   gap: 0.4rem;
 }
 
-.chip {
+.lang-tag {
   font-size: 0.65rem;
-  font-weight: 600;
-  padding: 0.22rem 0.55rem;
-  border-radius: 100px;
-  border: 1px solid var(--glass-border);
-  background: var(--glass-bg);
-  color: var(--text-secondary);
+  font-weight: 800;
   text-transform: uppercase;
-  letter-spacing: 0.05em;
-  transition: background 0.2s, border-color 0.2s, color 0.2s;
+  letter-spacing: 0.08em;
+  padding: 0.25rem 0.65rem;
+  background: var(--black);
+  color: var(--white);
+  border: 2px solid var(--black);
 }
 
-.chip:hover {
-  background: rgba(34, 211, 238, 0.1);
-  border-color: rgba(34, 211, 238, 0.35);
-  color: var(--cyan);
+.lang-tag.featured {
+  background: var(--blue);
+  border-color: var(--blue);
 }
 
-/* ── VOICE DEMO ─────────────────────────────────────────────── */
-.audio-card {
-  border-radius: var(--r-lg);
-  border: 1px solid var(--glass-border);
-  background: rgba(10, 10, 22, 0.7);
-  backdrop-filter: blur(24px);
-  -webkit-backdrop-filter: blur(24px);
-  padding: 2.25rem;
-  max-width: 760px;
-  margin: 0 auto;
-  box-shadow: 0 24px 60px rgba(0, 0, 0, 0.5);
+/* ── ASSIST LOOP ─────────────────────────────────────────── */
+.assist-loop { background: var(--black); color: var(--white); }
+.assist-loop .eyebrow { background: var(--yellow); color: var(--black); }
+.assist-loop .section-head h2 { color: var(--white); }
+.assist-loop .section-head p { color: rgba(255,255,255,0.6); }
+
+.assist-loop-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 1.5rem;
+}
+
+.loop-step {
+  background: rgba(255,255,255,0.04);
+  border: 2px solid rgba(255,255,255,0.15);
+  padding: 1.5rem;
   position: relative;
-  overflow: hidden;
+  transition: background 0.15s, border-color 0.15s;
 }
 
-.audio-card::before {
-  content: "";
-  position: absolute;
-  top: 0; left: 0; right: 0;
-  height: 1px;
-  background: linear-gradient(90deg, transparent, rgba(34, 211, 238, 0.6), rgba(139, 92, 246, 0.6), transparent);
+.loop-step:hover {
+  background: rgba(255,229,0,0.08);
+  border-color: var(--yellow);
 }
 
-.audio-header {
-  margin-bottom: 1.4rem;
-  padding-bottom: 0.9rem;
-  border-bottom: 1px solid var(--glass-border);
+.loop-step-num {
+  font-size: 2rem;
+  font-weight: 900;
+  color: var(--yellow);
+  line-height: 1;
+  margin-bottom: 0.5rem;
+  display: block;
 }
 
-.audio-header h3 {
-  font-size: 0.9rem;
-  font-weight: 700;
+.loop-step h3 {
+  font-size: 0.8rem;
   text-transform: uppercase;
   letter-spacing: 0.1em;
-  margin-bottom: 0.25rem;
-  color: var(--text-accent);
+  color: var(--white);
+  margin-bottom: 0.5rem;
 }
 
-.audio-header p {
-  font-size: 0.75rem;
-  color: var(--text-secondary);
+.loop-step p {
+  font-size: 0.78rem;
+  color: rgba(255,255,255,0.6);
   margin: 0;
 }
 
+/* ── VOICE DEMO ─────────────────────────────────────────── */
+.voice-demo { background: var(--blue); color: var(--white); }
+.voice-demo .eyebrow { background: var(--white); color: var(--black); border-color: var(--white); }
+.voice-demo .section-head h2 { color: var(--white); }
+.voice-demo .section-head p { color: rgba(255,255,255,0.75); }
+
+.demo-grid { max-width: 760px; margin: 0 auto; }
+
+.audio-card {
+  background: var(--black);
+  border: var(--border);
+  box-shadow: var(--shadow-lg);
+  padding: 2rem;
+}
+
+.audio-header h3 {
+  color: var(--white);
+  margin-bottom: 0.25rem;
+}
+
+.audio-header p {
+  font-size: 0.78rem;
+  color: rgba(255,255,255,0.55);
+}
+
 #audio-visualizer {
-  width: 100%;
-  border-radius: var(--r-sm);
-  border: 1px solid var(--glass-border);
   display: block;
-  margin-bottom: 1.4rem;
-  background: rgba(0, 0, 0, 0.5);
+  width: 100%;
+  height: 100px;
+  border: 2px solid rgba(255,255,255,0.1);
+  margin: 1rem 0;
+  background: rgba(255,255,255,0.03);
 }
 
 .audio-controls {
   display: flex;
   align-items: center;
-  gap: 0.85rem;
-  margin-bottom: 1.2rem;
+  gap: 1rem;
   flex-wrap: wrap;
+  margin: 1rem 0;
 }
 
 #seek-slider {
   flex: 1;
   min-width: 100px;
-  cursor: pointer;
-  height: 4px;
-  border: none;
-  border-radius: 100px;
-  background: rgba(255, 255, 255, 0.1);
+  height: 6px;
   appearance: none;
-  -webkit-appearance: none;
+  background: rgba(255,255,255,0.2);
+  border: 2px solid rgba(255,255,255,0.3);
+  cursor: pointer;
   outline: none;
 }
 
 #seek-slider::-webkit-slider-thumb {
-  -webkit-appearance: none;
+  appearance: none;
   width: 16px;
   height: 16px;
-  background: linear-gradient(135deg, var(--violet), var(--cyan));
-  border: none;
-  border-radius: 50%;
-  cursor: pointer;
-  box-shadow: 0 0 10px var(--glow-v);
-}
-
-#seek-slider::-moz-range-thumb {
-  width: 16px;
-  height: 16px;
-  background: linear-gradient(135deg, var(--violet), var(--cyan));
-  border: none;
-  border-radius: 50%;
+  background: var(--yellow);
+  border: 2px solid var(--black);
   cursor: pointer;
 }
 
 .audio-time {
   display: flex;
-  gap: 0.25rem;
-  font-size: 0.72rem;
+  gap: 0.4rem;
+  font-size: 0.75rem;
   font-weight: 700;
-  font-family: monospace;
-  padding: 0.3rem 0.6rem;
-  border-radius: var(--r-sm);
-  border: 1px solid var(--glass-border);
-  background: var(--glass-bg);
-  color: var(--text-secondary);
-  white-space: nowrap;
+  font-variant-numeric: tabular-nums;
+  color: rgba(255,255,255,0.7);
 }
 
-.segment-jumps,
-.accent-row { margin-bottom: 1.2rem; }
+.segment-jumps, .accent-row {
+  margin-top: 1rem;
+}
 
-.segment-jumps > p,
-.accent-row > p {
+.segment-jumps p, .accent-row p {
   font-size: 0.62rem;
-  font-weight: 700;
+  font-weight: 800;
   text-transform: uppercase;
-  letter-spacing: 0.12em;
+  letter-spacing: 0.15em;
+  color: rgba(255,255,255,0.45);
   margin-bottom: 0.5rem;
-  color: var(--text-secondary);
 }
 
 .segment-row {
@@ -1319,710 +941,643 @@ p { margin: 0 0 1rem; }
   gap: 0.4rem;
 }
 
-.segment-btn {
-  font-family: "Poppins", system-ui, sans-serif;
-  font-size: 0.68rem;
-  font-weight: 600;
+.segment-btn, .accent-tag {
+  font-size: 0.62rem;
+  font-weight: 800;
   text-transform: uppercase;
-  letter-spacing: 0.06em;
-  padding: 0.3rem 0.7rem;
-  border-radius: 100px;
-  border: 1px solid var(--glass-border);
-  background: var(--glass-bg);
-  color: var(--text-secondary);
+  letter-spacing: 0.08em;
+  padding: 0.25rem 0.6rem;
+  background: rgba(255,255,255,0.07);
+  border: 1.5px solid rgba(255,255,255,0.15);
+  color: rgba(255,255,255,0.8);
   cursor: pointer;
-  transition: background 0.2s, border-color 0.2s, color 0.2s;
+  transition: background 0.15s, border-color 0.15s;
 }
 
-.segment-btn:hover {
-  background: rgba(139, 92, 246, 0.1);
-  border-color: rgba(139, 92, 246, 0.3);
-  color: var(--text-accent);
-}
-
-.segment-btn.active {
-  background: linear-gradient(135deg, rgba(139, 92, 246, 0.35), rgba(34, 211, 238, 0.2));
-  border-color: rgba(139, 92, 246, 0.5);
-  color: var(--text-primary);
+.segment-btn:hover, .accent-tag:hover {
+  background: var(--yellow);
+  color: var(--black);
+  border-color: var(--yellow);
 }
 
 .transcript-strip {
+  margin-top: 1rem;
+  font-size: 0.8rem;
+  color: rgba(255,255,255,0.55);
+  font-style: italic;
+  min-height: 1.4em;
+  border-top: 1px solid rgba(255,255,255,0.1);
+  padding-top: 0.75rem;
   display: flex;
-  flex-direction: column;
-  gap: 0.45rem;
-  margin-top: 1.1rem;
-  border-top: 1px solid var(--glass-border);
-  padding-top: 1.1rem;
+  flex-wrap: wrap;
+  gap: 0.4rem;
 }
 
 .transcript-item {
-  font-family: "Poppins", system-ui, sans-serif;
-  font-size: 0.78rem;
-  font-weight: 400;
-  padding: 0.6rem 0.85rem;
-  border-radius: var(--r-sm);
-  border: 1px solid var(--glass-border);
-  background: var(--glass-bg);
-  color: var(--text-secondary);
+  font-size: 0.72rem;
+  font-style: normal;
+  font-weight: 600;
+  color: rgba(255,255,255,0.65);
+  background: rgba(255,255,255,0.05);
+  border: 1.5px solid rgba(255,255,255,0.12);
+  padding: 0.3rem 0.6rem;
   cursor: pointer;
   text-align: left;
-  transition: background 0.2s, border-color 0.2s, color 0.2s;
+  font-family: inherit;
+  transition: background 0.12s, border-color 0.12s, color 0.12s;
 }
 
 .transcript-item:hover {
-  background: rgba(34, 211, 238, 0.06);
-  border-color: rgba(34, 211, 238, 0.2);
-  color: var(--text-primary);
+  background: var(--yellow);
+  color: var(--black);
+  border-color: var(--yellow);
 }
 
-/* ── BENCHMARKS ─────────────────────────────────────────────── */
+/* Active state for segment/accent buttons */
+.segment-btn.active,
+.accent-tag.active {
+  background: var(--yellow);
+  color: var(--black);
+  border-color: var(--yellow);
+}
+
+/* ── BENCHMARKS ─────────────────────────────────────────── */
 .benchmark-spotlight {
   display: grid;
-  grid-template-columns: 2fr 1fr 1fr;
-  gap: 1.25rem;
-  margin-bottom: 1.75rem;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 1.5rem;
+  margin-bottom: 3rem;
 }
 
 .spotlight-card {
-  border-radius: var(--r-md);
-  border: 1px solid var(--glass-border);
-  background: var(--glass-bg);
-  backdrop-filter: blur(16px);
-  padding: 1.5rem;
-  transition: transform 0.25s, box-shadow 0.25s, border-color 0.25s;
-}
-
-.spotlight-card:hover {
-  transform: translateY(-4px) skewY(-0.4deg);
-  box-shadow: 0 16px 40px rgba(0, 0, 0, 0.4);
-  border-color: rgba(139, 92, 246, 0.25);
-}
-
-.spotlight-card.primary {
-  background: linear-gradient(160deg, rgba(139, 92, 246, 0.15) 0%, rgba(34, 211, 238, 0.08) 100%);
-  border-color: rgba(139, 92, 246, 0.25);
-  box-shadow: 0 8px 30px rgba(139, 92, 246, 0.15);
-}
-
-.spotlight-label {
-  font-size: 0.65rem;
-  font-weight: 600;
-  text-transform: uppercase;
-  letter-spacing: 0.1em;
-  margin-bottom: 0.45rem;
-  color: var(--text-secondary);
+  background: var(--yellow);
+  border: var(--border);
+  box-shadow: var(--shadow);
+  padding: 2rem 1.5rem;
+  text-align: center;
 }
 
 .spotlight-value {
-  font-size: 2.2rem;
+  font-size: 3rem;
   font-weight: 900;
   line-height: 1;
-  margin-bottom: 0.45rem;
-  letter-spacing: -0.025em;
-  background: linear-gradient(135deg, var(--text-primary), var(--violet));
-  -webkit-background-clip: text;
-  -webkit-text-fill-color: transparent;
-  background-clip: text;
+  color: var(--black);
+  display: block;
 }
 
-.spotlight-card.primary .spotlight-value {
-  background: linear-gradient(135deg, #c4b5fd, var(--cyan));
-  -webkit-background-clip: text;
-  -webkit-text-fill-color: transparent;
-  background-clip: text;
-}
-
-.spotlight-note {
-  font-size: 0.73rem;
-  font-weight: 400;
-  color: var(--text-secondary);
-  margin: 0;
-  line-height: 1.45;
+.spotlight-label {
+  font-size: 0.7rem;
+  font-weight: 800;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: var(--black);
+  opacity: 0.65;
+  margin-top: 0.35rem;
+  display: block;
 }
 
 .benchmark-grid {
   display: grid;
-  grid-template-columns: repeat(3, 1fr);
-  gap: 1.25rem;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 1.5rem;
 }
 
 .benchmark-card {
-  border-radius: var(--r-md);
-  border: 1px solid var(--glass-border);
-  background: var(--glass-bg);
-  backdrop-filter: blur(16px);
+  background: var(--white);
+  border: var(--border);
+  box-shadow: var(--shadow);
   padding: 1.5rem;
-  transition: transform 0.25s, box-shadow 0.25s, border-color 0.25s, background 0.25s;
-  position: relative;
-  overflow: hidden;
+  transition: transform 0.1s, box-shadow 0.1s;
 }
 
 .benchmark-card:hover {
-  transform: translateY(-4px) skewY(-0.3deg);
-  box-shadow: 0 12px 40px rgba(0, 0, 0, 0.4);
-  border-color: rgba(139, 92, 246, 0.25);
-  background: var(--glass-bg-md);
-}
-
-.benchmark-topline {
-  display: flex;
-  gap: 0.45rem;
-  flex-wrap: wrap;
-  margin-bottom: 0.75rem;
-}
-
-.benchmark-badge {
-  font-size: 0.6rem;
-  font-weight: 700;
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
-  padding: 0.2rem 0.55rem;
-  border-radius: 100px;
-  border: 1px solid rgba(139, 92, 246, 0.35);
-  background: rgba(139, 92, 246, 0.1);
-  color: var(--text-accent);
-}
-
-.benchmark-signal {
-  font-size: 0.6rem;
-  font-weight: 700;
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
-  padding: 0.2rem 0.55rem;
-  border-radius: 100px;
-  border: 1px solid var(--glass-border);
-  background: var(--glass-bg);
-  color: var(--text-secondary);
-}
-
-.benchmark-kpi {
-  font-size: 2rem;
-  font-weight: 900;
-  line-height: 1;
-  margin-bottom: 0.4rem;
-  letter-spacing: -0.025em;
-  background: linear-gradient(135deg, var(--text-primary) 30%, var(--violet));
-  -webkit-background-clip: text;
-  -webkit-text-fill-color: transparent;
-  background-clip: text;
+  transform: translate(-3px, -3px);
+  box-shadow: var(--shadow-lg);
 }
 
 .benchmark-card h3 {
   font-size: 0.75rem;
-  font-weight: 700;
   text-transform: uppercase;
-  letter-spacing: 0.04em;
-  margin-bottom: 0.4rem;
-  color: var(--text-primary);
+  letter-spacing: 0.12em;
+  margin-bottom: 0.5rem;
+  opacity: 0.6;
 }
 
-.benchmark-card p {
-  font-size: 0.76rem;
-  color: var(--text-secondary);
+.benchmark-range {
+  font-size: 1.6rem;
+  font-weight: 900;
+  color: var(--blue);
+  line-height: 1;
+  display: block;
+}
+
+.benchmark-note {
+  font-size: 0.72rem;
+  opacity: 0.55;
+  margin: 0.4rem 0 0;
+}
+
+/* ── INTEGRATIONS ─────────────────────────────────────────── */
+.integrations { background: var(--white); }
+
+.stack-strip {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  justify-content: center;
+  margin-bottom: 3rem;
+}
+
+.stack-strip span {
+  font-size: 0.75rem;
+  font-weight: 800;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  padding: 0.6rem 1.25rem;
+  background: var(--black);
+  color: var(--yellow);
+  border: 2px solid var(--black);
+}
+
+.timeline-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 0;
+  border: var(--border);
+}
+
+.timeline-grid article {
+  padding: 1.75rem;
+  border-right: 3px solid var(--black);
+  counter-increment: step;
+  position: relative;
+}
+
+.timeline-grid article:last-child { border-right: none; }
+
+.timeline-grid article h3 {
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  margin-bottom: 0.6rem;
+  background: var(--yellow);
+  display: inline-block;
+  padding: 0.1rem 0.4rem;
+}
+
+.timeline-grid article p {
+  font-size: 0.82rem;
+  opacity: 0.7;
+  margin: 0;
+}
+
+/* ── GUARDRAILS ─────────────────────────────────────────── */
+.guardrails { background: var(--black); color: var(--white); }
+.guardrails .eyebrow { background: var(--blue); color: var(--white); border-color: var(--blue); }
+.guardrails .section-head h2 { color: var(--white); }
+
+.guardrail-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 1.5rem;
+}
+
+.guardrail-grid article {
+  background: rgba(255,255,255,0.04);
+  border: 2px solid rgba(255,255,255,0.12);
+  padding: 1.75rem;
+  transition: border-color 0.15s, background 0.15s;
+}
+
+.guardrail-grid article:hover {
+  border-color: var(--yellow);
+  background: rgba(255,229,0,0.06);
+}
+
+.guardrail-grid article h3 {
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: var(--yellow);
+  margin-bottom: 0.6rem;
+}
+
+.guardrail-grid article p {
+  font-size: 0.82rem;
+  color: rgba(255,255,255,0.6);
+  margin: 0;
+}
+
+/* ── ASSIST LOOP CARDS ─────────────────────────────────── */
+.assist-loop-card {
+  background: rgba(255,255,255,0.04);
+  border: 2px solid rgba(255,255,255,0.15);
+  padding: 1.5rem;
+  position: relative;
+  transition: background 0.15s, border-color 0.15s;
+}
+
+.assist-loop-card:hover {
+  background: rgba(255,229,0,0.08);
+  border-color: var(--yellow);
+}
+
+.assist-kicker {
+  font-size: 0.58rem;
+  font-weight: 800;
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  background: var(--yellow);
+  color: var(--black);
+  padding: 0.15rem 0.45rem;
+  display: inline-block;
   margin-bottom: 0.75rem;
-  line-height: 1.55;
+}
+
+.assist-loop-card h3 {
+  font-size: 0.82rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--white);
+  margin-bottom: 0.5rem;
+}
+
+.assist-loop-card p {
+  font-size: 0.78rem;
+  color: rgba(255,255,255,0.6);
+  margin-bottom: 0.75rem;
+}
+
+.assist-metric {
+  font-size: 0.65rem;
+  font-weight: 800;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: var(--yellow);
+  border-top: 1px solid rgba(255,255,255,0.1);
+  padding-top: 0.6rem;
+}
+
+/* ── LANGUAGE CHIPS ─────────────────────────────────────── */
+.chip {
+  font-size: 0.65rem;
+  font-weight: 800;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  padding: 0.25rem 0.65rem;
+  background: var(--black);
+  color: var(--white);
+  border: 2px solid var(--black);
+  cursor: default;
+  transition: background 0.1s, color 0.1s;
+}
+
+.chip:hover {
+  background: var(--yellow);
+  color: var(--black);
+  border-color: var(--black);
+}
+
+/* ── BENCHMARK CARDS (JS-rendered) ──────────────────────── */
+.benchmark-topline {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 0.75rem;
+}
+
+.benchmark-badge {
+  font-size: 0.58rem;
+  font-weight: 800;
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+  background: var(--black);
+  color: var(--yellow);
+  padding: 0.15rem 0.45rem;
+  border: 1.5px solid var(--black);
+}
+
+.benchmark-signal {
+  font-size: 0.58rem;
+  font-weight: 800;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: rgba(0,0,0,0.4);
+}
+
+.benchmark-kpi {
+  font-size: 1.6rem;
+  font-weight: 900;
+  color: var(--blue);
+  line-height: 1;
+  display: block;
+  margin-bottom: 0.35rem;
 }
 
 .bar-track {
-  height: 4px;
-  background: rgba(255, 255, 255, 0.06);
-  border-radius: 100px;
+  height: 8px;
+  background: rgba(0,0,0,0.08);
+  border: 2px solid var(--black);
+  margin-top: 0.75rem;
   overflow: hidden;
 }
 
 .bar-track i {
   display: block;
   height: 100%;
-  width: 0;
-  background: linear-gradient(90deg, var(--violet), var(--cyan));
-  border-radius: 100px;
-  transition: width 1.2s ease;
-  box-shadow: 0 0 8px rgba(139, 92, 246, 0.5);
+  width: 0%;
+  background: var(--blue);
+  font-style: normal;
+  transition: width 1s ease;
 }
 
-/* ── INTEGRATIONS ─────────────────────────────────────────────── */
-.stack-strip {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.75rem;
-  justify-content: center;
-  margin-bottom: 2.75rem;
+/* ── SPOTLIGHT NOTE ─────────────────────────────────────── */
+.spotlight-note {
+  font-size: 0.7rem;
+  color: rgba(0,0,0,0.5);
+  text-transform: none;
+  letter-spacing: 0;
+  font-weight: 400;
+  margin-top: 0.35rem;
+  display: block;
 }
 
-.stack-strip span {
-  font-size: 0.72rem;
-  font-weight: 700;
-  text-transform: uppercase;
-  letter-spacing: 0.1em;
-  padding: 0.55rem 1.4rem;
-  border-radius: 100px;
-  border: 1px solid var(--glass-border);
-  background: var(--glass-bg);
-  color: var(--text-secondary);
-  backdrop-filter: blur(12px);
-  transition: transform 0.2s, box-shadow 0.2s, background 0.2s, border-color 0.2s, color 0.2s;
-  cursor: default;
-}
+/* ── FAQ (uses <details>/<summary>) ──────────────────────── */
+.faq { background: var(--bg); }
 
-.stack-strip span:hover {
-  transform: translateY(-2px);
-  box-shadow: 0 8px 20px rgba(139, 92, 246, 0.2);
-  background: rgba(139, 92, 246, 0.1);
-  border-color: rgba(139, 92, 246, 0.35);
-  color: var(--text-accent);
-}
-
-.timeline-grid {
-  display: grid;
-  grid-template-columns: repeat(3, 1fr);
-  border-radius: var(--r-lg);
-  border: 1px solid var(--glass-border);
-  overflow: hidden;
-  box-shadow: 0 20px 50px rgba(0, 0, 0, 0.35);
-}
-
-.timeline-grid article {
-  padding: 2rem;
-  border-right: 1px solid var(--glass-border);
-  background: var(--glass-bg);
-  backdrop-filter: blur(16px);
-  transition: background 0.25s;
-  position: relative;
-}
-
-.timeline-grid article::before {
-  content: "";
-  position: absolute;
-  top: 0; left: 0; right: 0;
-  height: 2px;
-  background: linear-gradient(90deg, var(--violet), var(--cyan));
-  opacity: 0;
-  transition: opacity 0.25s;
-}
-
-.timeline-grid article:last-child { border-right: none; }
-
-.timeline-grid article:hover {
-  background: var(--glass-bg-md);
-}
-
-.timeline-grid article:hover::before { opacity: 1; }
-
-.timeline-grid h3 {
-  font-size: 0.8rem;
-  font-weight: 700;
-  text-transform: uppercase;
-  letter-spacing: 0.1em;
-  margin-bottom: 0.7rem;
-  padding-bottom: 0.5rem;
-  border-bottom: 1px solid var(--glass-border);
-  color: var(--text-accent);
-}
-
-.timeline-grid p {
-  font-size: 0.8rem;
-  color: var(--text-secondary);
-  margin: 0;
-  line-height: 1.6;
-}
-
-/* ── GUARDRAILS ─────────────────────────────────────────────── */
-.guardrail-grid {
-  display: grid;
-  grid-template-columns: repeat(3, 1fr);
-  gap: 1.25rem;
-}
-
-.guardrail-grid article {
-  border-radius: var(--r-md);
-  border: 1px solid var(--glass-border);
-  background: var(--glass-bg);
-  backdrop-filter: blur(16px);
-  padding: 1.6rem;
-  transition: transform 0.25s, box-shadow 0.25s, border-color 0.25s, background 0.25s;
-  position: relative;
-  overflow: hidden;
-}
-
-.guardrail-grid article::before {
-  content: "";
-  position: absolute;
-  bottom: 0; left: 0; right: 0;
-  height: 2px;
-  background: linear-gradient(90deg, var(--rose), transparent);
-  opacity: 0.6;
-}
-
-.guardrail-grid article:hover {
-  transform: translateY(-4px) skewY(-0.4deg);
-  box-shadow: 0 12px 40px rgba(0, 0, 0, 0.4);
-  border-color: rgba(244, 63, 94, 0.2);
-  background: var(--glass-bg-md);
-}
-
-.guardrail-grid h3 {
-  font-size: 0.8rem;
-  font-weight: 700;
-  text-transform: uppercase;
-  letter-spacing: 0.06em;
-  margin-bottom: 0.5rem;
-  padding-bottom: 0.45rem;
-  border-bottom: 1px solid rgba(244, 63, 94, 0.2);
-  color: #fb7185;
-}
-
-.guardrail-grid p {
-  font-size: 0.8rem;
-  color: var(--text-secondary);
-  margin: 0;
-  line-height: 1.55;
-}
-
-/* ── FAQ ─────────────────────────────────────────────────────── */
 .faq-list {
-  max-width: 720px;
+  max-width: 740px;
   margin: 0 auto;
   display: flex;
   flex-direction: column;
-  gap: 0.6rem;
+  border-top: var(--border);
 }
 
 .faq-item {
-  border-radius: var(--r-md);
-  border: 1px solid var(--glass-border);
-  background: var(--glass-bg);
-  backdrop-filter: blur(16px);
+  border-bottom: 3px solid var(--black);
   overflow: hidden;
-  transition: border-color 0.25s, background 0.25s;
 }
 
-.faq-item[open] {
-  background: rgba(139, 92, 246, 0.06);
-  border-color: rgba(139, 92, 246, 0.25);
-}
-
-.faq-item summary {
-  font-size: 0.85rem;
-  font-weight: 600;
-  padding: 1.1rem 1.4rem;
+details.faq-item summary {
+  font-size: 0.88rem;
+  font-weight: 800;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  padding: 1.2rem 1rem;
   cursor: pointer;
   list-style: none;
   display: flex;
   justify-content: space-between;
   align-items: center;
-  color: var(--text-primary);
-  transition: color 0.2s;
+  gap: 1rem;
+  background: var(--white);
+  transition: background 0.15s;
 }
 
-.faq-item summary:hover { color: var(--text-accent); }
+details.faq-item summary::-webkit-details-marker { display: none; }
 
-.faq-item summary::-webkit-details-marker { display: none; }
-.faq-item summary::marker { display: none; }
-
-.faq-item summary::after {
+details.faq-item summary::after {
   content: "+";
-  font-size: 1.3rem;
-  font-weight: 700;
+  font-size: 1.4rem;
+  font-weight: 900;
   flex-shrink: 0;
-  margin-left: 1rem;
-  color: var(--violet);
+  line-height: 1;
 }
 
-.faq-item[open] summary::after { content: "−"; }
+details.faq-item[open] summary {
+  background: var(--yellow);
+}
 
-.faq-item p {
+details.faq-item[open] summary::after { content: "−"; }
+
+details.faq-item summary:hover { background: var(--yellow); }
+
+details.faq-item p {
+  font-size: 0.85rem;
+  line-height: 1.7;
+  color: rgba(0,0,0,0.7);
+  padding: 0.75rem 1rem 1.25rem;
   margin: 0;
-  padding: 0.9rem 1.4rem 1.2rem;
-  font-size: 0.84rem;
-  color: var(--text-secondary);
-  border-top: 1px solid var(--glass-border);
-  line-height: 1.65;
+  background: var(--white);
+  border-top: 2px solid rgba(0,0,0,0.07);
 }
 
-/* ── CTA ─────────────────────────────────────────────────────── */
-.cta {
-  background: transparent;
-  position: relative;
-  overflow: hidden;
-}
-
-.cta::before {
-  content: "";
-  position: absolute;
-  inset: -10% 0;
-  background: linear-gradient(160deg,
-    rgba(139, 92, 246, 0.1) 0%,
-    rgba(34, 211, 238, 0.06) 50%,
-    rgba(244, 63, 94, 0.05) 100%);
-  transform: skewY(-3deg);
-  border-top: 1px solid rgba(139, 92, 246, 0.15);
-  border-bottom: 1px solid rgba(34, 211, 238, 0.1);
-}
+/* ── CTA SECTION ─────────────────────────────────────────── */
+.cta { background: var(--black); color: var(--white); }
 
 .cta-grid {
   display: grid;
   grid-template-columns: 1fr 1fr;
-  gap: 4.5rem;
+  gap: 4rem;
   align-items: start;
-  position: relative;
-  z-index: 1;
 }
 
-.cta h2 {
-  background: linear-gradient(135deg, var(--text-primary), #c4b5fd);
-  -webkit-background-clip: text;
-  -webkit-text-fill-color: transparent;
-  background-clip: text;
-}
+.cta-copy .eyebrow { background: var(--yellow); color: var(--black); }
+.cta-copy h2 { color: var(--white); }
 
 .cta-copy p {
-  color: var(--text-secondary);
   font-size: 0.9rem;
-  line-height: 1.7;
+  color: rgba(255,255,255,0.65);
 }
 
 .cta-bullets {
   list-style: none;
-  margin: 1.2rem 0 0;
   padding: 0;
+  margin: 1.5rem 0 0;
   display: flex;
   flex-direction: column;
-  gap: 0.5rem;
+  gap: 0.65rem;
 }
 
 .cta-bullets li {
-  font-size: 0.84rem;
-  font-weight: 400;
-  padding: 0.5rem 0.85rem 0.5rem 1.6rem;
+  font-size: 0.82rem;
+  font-weight: 600;
+  color: rgba(255,255,255,0.75);
+  padding-left: 1.5rem;
   position: relative;
-  color: var(--text-secondary);
-  border-radius: var(--r-sm);
-  border: 1px solid rgba(139, 92, 246, 0.2);
-  background: rgba(139, 92, 246, 0.06);
 }
 
 .cta-bullets li::before {
   content: "→";
   position: absolute;
-  left: 0.45rem;
-  color: var(--violet);
-  font-weight: 700;
+  left: 0;
+  color: var(--yellow);
+  font-weight: 900;
 }
 
-/* ── DEMO FORM ─────────────────────────────────────────────── */
+/* Form */
 .demo-form {
+  background: var(--bg);
+  border: var(--border);
+  box-shadow: var(--shadow-lg);
+  padding: 2rem;
   display: flex;
   flex-direction: column;
-  gap: 0.85rem;
-  border-radius: var(--r-lg);
-  border: 1px solid rgba(139, 92, 246, 0.25);
-  padding: 2rem;
-  background: rgba(12, 12, 28, 0.7);
-  backdrop-filter: blur(24px);
-  -webkit-backdrop-filter: blur(24px);
-  box-shadow: 0 8px 40px rgba(139, 92, 246, 0.15), 0 0 80px rgba(0, 0, 0, 0.3);
-  position: relative;
-}
-
-.demo-form::before {
-  content: "";
-  position: absolute;
-  top: 0; left: 0; right: 0;
-  height: 1px;
-  background: linear-gradient(90deg, transparent, rgba(139, 92, 246, 0.6), rgba(34, 211, 238, 0.6), transparent);
-  border-radius: var(--r-lg) var(--r-lg) 0 0;
+  gap: 0.75rem;
 }
 
 .demo-form label {
   font-size: 0.65rem;
-  font-weight: 700;
+  font-weight: 800;
   text-transform: uppercase;
-  letter-spacing: 0.1em;
-  color: var(--text-secondary);
+  letter-spacing: 0.15em;
+  color: var(--black);
   margin-bottom: -0.4rem;
 }
 
 .demo-form input,
 .demo-form select,
 .demo-form textarea {
-  font-family: "Poppins", system-ui, sans-serif;
-  font-size: 0.85rem;
-  font-weight: 400;
-  padding: 0.7rem 0.95rem;
-  border-radius: var(--r-sm);
-  border: 1px solid var(--glass-border);
-  background: rgba(255, 255, 255, 0.04);
-  color: var(--text-primary);
+  font-family: inherit;
+  font-size: 0.88rem;
+  font-weight: 600;
+  padding: 0.7rem 0.85rem;
+  background: var(--white);
+  border: 2px solid var(--black);
+  color: var(--black);
   outline: none;
   width: 100%;
-  transition: border-color 0.2s, box-shadow 0.2s, background 0.2s;
+  transition: border-color 0.15s, box-shadow 0.15s;
+  border-radius: 0;
+  appearance: none;
 }
-
-.demo-form input::placeholder,
-.demo-form textarea::placeholder {
-  color: var(--text-secondary);
-  opacity: 0.5;
-}
-
-.demo-form select option { background: #0d0d1a; color: var(--text-primary); }
 
 .demo-form input:focus,
 .demo-form select:focus,
 .demo-form textarea:focus {
-  border-color: rgba(139, 92, 246, 0.5);
-  background: rgba(139, 92, 246, 0.06);
-  box-shadow: 0 0 0 3px rgba(139, 92, 246, 0.12);
+  border-color: var(--blue);
+  box-shadow: 3px 3px 0 var(--blue);
 }
 
-.demo-form textarea { resize: vertical; }
+.demo-form textarea { resize: vertical; min-height: 90px; }
 
-.demo-form button[type="submit"] { width: 100%; }
+.demo-form .btn-primary {
+  margin-top: 0.5rem;
+  width: 100%;
+  font-size: 0.88rem;
+  padding: 0.9rem;
+}
 
-.honey-input { display: none; }
+.honey-input { display: none !important; }
 
 .form-note {
-  font-size: 0.7rem;
-  color: var(--text-secondary);
-  margin: 0;
+  font-size: 0.72rem;
   text-align: center;
-  opacity: 0.7;
+  color: rgba(0,0,0,0.45);
+  margin: 0;
 }
 
 .form-note a {
-  color: var(--violet);
   text-decoration: underline;
-  font-weight: 600;
+  font-weight: 700;
 }
 
-/* ── FOOTER ─────────────────────────────────────────────────── */
+/* ── FOOTER ─────────────────────────────────────────────── */
 .site-footer {
-  background: rgba(0, 0, 0, 0.5);
-  backdrop-filter: blur(12px);
-  color: var(--text-secondary);
-  padding: 2.25rem 0;
-  border-top: 1px solid var(--glass-border);
-  position: relative;
-  z-index: 1;
+  background: var(--yellow);
+  border-top: var(--border);
+  padding: 2rem 0;
 }
 
 .footer-inner {
   display: flex;
   justify-content: space-between;
   align-items: center;
+  gap: 1rem;
   flex-wrap: wrap;
-  gap: 0.75rem;
 }
 
 .footer-inner p {
-  font-size: 0.72rem;
-  font-weight: 500;
-  margin: 0;
+  font-size: 0.75rem;
+  font-weight: 700;
   text-transform: uppercase;
-  letter-spacing: 0.08em;
-  opacity: 0.5;
+  letter-spacing: 0.1em;
+  color: var(--black);
+  margin: 0;
+  opacity: 0.7;
 }
 
-/* ── TOAST ─────────────────────────────────────────────────── */
+/* ── TOAST ─────────────────────────────────────────────── */
 .toast {
   position: fixed;
-  bottom: 1.75rem;
-  left: 50%;
-  transform: translateX(-50%) translateY(150%);
-  background: rgba(12, 12, 28, 0.9);
-  backdrop-filter: blur(20px);
-  color: var(--text-accent);
-  font-size: 0.78rem;
-  font-weight: 600;
-  padding: 0.9rem 1.5rem;
-  border-radius: var(--r-md);
-  border: 1px solid rgba(139, 92, 246, 0.4);
-  box-shadow: 0 8px 40px rgba(139, 92, 246, 0.25), 0 0 60px rgba(0, 0, 0, 0.5);
-  z-index: 9999;
+  bottom: 2rem;
+  right: 2rem;
+  z-index: 999;
+  font-size: 0.82rem;
+  font-weight: 800;
   text-transform: uppercase;
-  letter-spacing: 0.08em;
-  max-width: min(460px, 90vw);
-  text-align: center;
-  transition: transform 0.3s cubic-bezier(0.34, 1.56, 0.64, 1);
+  letter-spacing: 0.1em;
+  padding: 0.75rem 1.25rem;
+  background: var(--yellow);
+  color: var(--black);
+  border: var(--border);
+  box-shadow: var(--shadow);
+  opacity: 0;
+  transform: translateY(12px);
+  transition: opacity 0.25s, transform 0.25s;
   pointer-events: none;
 }
 
-.toast.show { transform: translateX(-50%) translateY(0); }
-
-.toast.error {
-  border-color: rgba(244, 63, 94, 0.4);
-  color: #fb7185;
+.toast.show {
+  opacity: 1;
+  transform: translateY(0);
 }
 
-/* ── ANIMATIONS ─────────────────────────────────────────────── */
-@keyframes float-y {
-  0%, 100% { transform: translateY(0); }
-  50%       { transform: translateY(-8px); }
+/* ── UTILITY: REVEAL ─────────────────────────────────────── */
+[data-reveal] {
+  opacity: 0;
+  transform: translateY(20px);
+  transition: opacity 0.5s ease, transform 0.5s ease;
 }
 
-@keyframes pulse-glow {
-  0%, 100% { opacity: 0.18; }
-  50%       { opacity: 0.3; }
+[data-reveal].visible {
+  opacity: 1;
+  transform: translateY(0);
 }
 
-@keyframes gradient-shift {
-  0%   { background-position: 0% 50%; }
-  50%  { background-position: 100% 50%; }
-  100% { background-position: 0% 50%; }
+/* ── SECTION STRIPE SEPARATORS ───────────────────────────── */
+.section + .section {
+  border-top: 3px solid var(--black);
 }
 
-.ambient-a { animation: float-y 14s ease-in-out infinite, pulse-glow 8s ease-in-out infinite; }
-.ambient-b { animation: float-y 16s ease-in-out infinite 2s, pulse-glow 10s ease-in-out infinite 1s; }
-.ambient-c { animation: float-y 18s ease-in-out infinite 4s, pulse-glow 12s ease-in-out infinite 2s; }
-
-.hero-floating-a { animation: float-y 2.8s ease-in-out infinite; }
-.hero-floating-b { animation: float-y 3.3s ease-in-out infinite 0.5s; }
-
-/* ── RESPONSIVE ─────────────────────────────────────────────── */
-@media (max-width: 1000px) {
-  .pain-grid { grid-template-columns: repeat(2, 1fr); }
-  .assist-loop-grid { grid-template-columns: repeat(2, 1fr); }
+.legacy + .section,
+.guardrails + .section,
+.assist-loop + .section,
+.voice-demo + .section,
+.cta + .section {
+  border-top: none;
 }
 
-@media (max-width: 860px) {
+/* ── RESPONSIVE ───────────────────────────────────────────── */
+@media (max-width: 900px) {
   .hero-grid,
   .detail-grid,
-  .cta-grid { grid-template-columns: 1fr; }
-
-  .legacy-shell { grid-template-columns: 1fr; }
-
-  .legacy-before {
-    border-right: none;
-    border-bottom: 1px solid var(--glass-border);
-  }
-
+  .legacy-shell,
   .product-grid,
-  .benchmark-spotlight { grid-template-columns: 1fr; }
-
-  .benchmark-grid,
-  .guardrail-grid { grid-template-columns: 1fr 1fr; }
-
-  .timeline-grid { grid-template-columns: 1fr; }
-
-  .timeline-grid article {
-    border-right: none;
-    border-bottom: 1px solid var(--glass-border);
+  .cta-grid {
+    grid-template-columns: 1fr;
+    gap: 2rem;
   }
-  .timeline-grid article:last-child { border-bottom: none; }
 
   .hero-proof { grid-template-columns: 1fr; }
+
+  .guardrail-grid,
+  .timeline-grid { grid-template-columns: 1fr; }
+  .timeline-grid article { border-right: none; border-bottom: 3px solid var(--black); }
+  .timeline-grid article:last-child { border-bottom: none; }
+
+  .hero-visual { order: -1; }
+
+  .site-nav { display: none; }
+
+  h1 { font-size: clamp(2rem, 7vw, 3rem); }
+  h2 { font-size: clamp(1.5rem, 5vw, 2rem); }
 }
 
 @media (max-width: 600px) {
-  .site-nav { display: none; }
-
-  .pain-grid,
-  .benchmark-grid,
-  .guardrail-grid,
-  .assist-loop-grid { grid-template-columns: 1fr; }
-
-  .hero-metrics { flex-direction: column; }
+  .section { padding: 60px 0; }
+  .hero { padding: 60px 0; }
   .hero-cta { flex-direction: column; }
-  .hero-cta .btn { width: 100%; justify-content: center; }
-
-  .section { padding: 70px 0; }
+  .hero-metrics { flex-direction: column; gap: 0.75rem; }
+  .product-grid { grid-template-columns: 1fr; }
 }

--- a/styles.css
+++ b/styles.css
@@ -1458,7 +1458,14 @@ details.faq-item p {
   padding: 0.9rem;
 }
 
-.honey-input { display: none !important; }
+.honey-input {
+  position: absolute;
+  left: -9999px;
+  opacity: 0;
+  pointer-events: none;
+  width: 0;
+  height: 0;
+}
 
 .form-note {
   font-size: 0.72rem;

--- a/tests/generated/page_home.spec.js
+++ b/tests/generated/page_home.spec.js
@@ -15,19 +15,17 @@ test.describe('VOCA AI landing page', () => {
   test('should load page successfully', async ({ page }) => {
     // Verify page loads
     await expect(page).toHaveURL(new RegExp('\/'));
-    
+
     // Wait for page to be ready
     await page.waitForLoadState('domcontentloaded');
   });
 
   test('should display header component', async ({ page }) => {
-    // Look for header by various selectors
-    const element = page.locator(`
-      [data-testid="header"],
-      [class*="header"],
-      text=header
-    `.replace(/\s+/g, '').split(',').join(', '));
-    
+    // Look for header by various selectors using valid Playwright locator chaining
+    const element = page.locator('[data-testid="header"]')
+      .or(page.locator('[class*="header"]'))
+      .or(page.locator('text=header'));
+
     // At least one selector should match
     await expect(element.first()).toBeVisible({ timeout: 10000 }).catch(() => {
       // Fallback: check if any text contains the component name
@@ -36,13 +34,11 @@ test.describe('VOCA AI landing page', () => {
   });
 
   test('should display hero component', async ({ page }) => {
-    // Look for hero by various selectors
-    const element = page.locator(`
-      [data-testid="hero"],
-      [class*="hero"],
-      text=hero
-    `.replace(/\s+/g, '').split(',').join(', '));
-    
+    // Look for hero by various selectors using valid Playwright locator chaining
+    const element = page.locator('[data-testid="hero"]')
+      .or(page.locator('[class*="hero"]'))
+      .or(page.locator('text=hero'));
+
     // At least one selector should match
     await expect(element.first()).toBeVisible({ timeout: 10000 }).catch(() => {
       // Fallback: check if any text contains the component name
@@ -51,13 +47,11 @@ test.describe('VOCA AI landing page', () => {
   });
 
   test('should display products component', async ({ page }) => {
-    // Look for products by various selectors
-    const element = page.locator(`
-      [data-testid="products"],
-      [class*="products"],
-      text=products
-    `.replace(/\s+/g, '').split(',').join(', '));
-    
+    // Look for products by various selectors using valid Playwright locator chaining
+    const element = page.locator('[data-testid="products"]')
+      .or(page.locator('[class*="products"]'))
+      .or(page.locator('text=products'));
+
     // At least one selector should match
     await expect(element.first()).toBeVisible({ timeout: 10000 }).catch(() => {
       // Fallback: check if any text contains the component name
@@ -66,13 +60,11 @@ test.describe('VOCA AI landing page', () => {
   });
 
   test('should display assist-loop component', async ({ page }) => {
-    // Look for assist-loop by various selectors
-    const element = page.locator(`
-      [data-testid="assist-loop"],
-      [class*="assist-loop"],
-      text=assist-loop
-    `.replace(/\s+/g, '').split(',').join(', '));
-    
+    // Look for assist-loop by various selectors using valid Playwright locator chaining
+    const element = page.locator('[data-testid="assist-loop"]')
+      .or(page.locator('[class*="assist-loop"]'))
+      .or(page.locator('text=assist-loop'));
+
     // At least one selector should match
     await expect(element.first()).toBeVisible({ timeout: 10000 }).catch(() => {
       // Fallback: check if any text contains the component name
@@ -81,13 +73,11 @@ test.describe('VOCA AI landing page', () => {
   });
 
   test('should display voice-demo component', async ({ page }) => {
-    // Look for voice-demo by various selectors
-    const element = page.locator(`
-      [data-testid="voice-demo"],
-      [class*="voice-demo"],
-      text=voice-demo
-    `.replace(/\s+/g, '').split(',').join(', '));
-    
+    // Look for voice-demo by various selectors using valid Playwright locator chaining
+    const element = page.locator('[data-testid="voice-demo"]')
+      .or(page.locator('[class*="voice-demo"]'))
+      .or(page.locator('text=voice-demo'));
+
     // At least one selector should match
     await expect(element.first()).toBeVisible({ timeout: 10000 }).catch(() => {
       // Fallback: check if any text contains the component name
@@ -96,13 +86,11 @@ test.describe('VOCA AI landing page', () => {
   });
 
   test('should display benchmarks component', async ({ page }) => {
-    // Look for benchmarks by various selectors
-    const element = page.locator(`
-      [data-testid="benchmarks"],
-      [class*="benchmarks"],
-      text=benchmarks
-    `.replace(/\s+/g, '').split(',').join(', '));
-    
+    // Look for benchmarks by various selectors using valid Playwright locator chaining
+    const element = page.locator('[data-testid="benchmarks"]')
+      .or(page.locator('[class*="benchmarks"]'))
+      .or(page.locator('text=benchmarks'));
+
     // At least one selector should match
     await expect(element.first()).toBeVisible({ timeout: 10000 }).catch(() => {
       // Fallback: check if any text contains the component name
@@ -111,13 +99,11 @@ test.describe('VOCA AI landing page', () => {
   });
 
   test('should display cta component', async ({ page }) => {
-    // Look for cta by various selectors
-    const element = page.locator(`
-      [data-testid="cta"],
-      [class*="cta"],
-      text=cta
-    `.replace(/\s+/g, '').split(',').join(', '));
-    
+    // Look for cta by various selectors using valid Playwright locator chaining
+    const element = page.locator('[data-testid="cta"]')
+      .or(page.locator('[class*="cta"]'))
+      .or(page.locator('text=cta'));
+
     // At least one selector should match
     await expect(element.first()).toBeVisible({ timeout: 10000 }).catch(() => {
       // Fallback: check if any text contains the component name


### PR DESCRIPTION
## Summary

- Replaces the dark glassmorphism/skew-morphism theme with a bold **New Brutalist** design
- Cream (`#F5F0E8`) background with `#111` black, electric yellow (`#FFE500`), blue (`#0047FF`), and red (`#FF2400`) accent palette
- Thick 3px black borders and offset box-shadows (`5px 5px 0 #111`) on all cards/buttons — creates the signature brutalist stacked 3D look
- Heavy uppercase typography using Space Grotesk (900 weight) — no border-radius, flat colors throughout
- Yellow header bar with black nav, chunky interactive buttons with active press states
- Hero section redesigned: black background, yellow metric values, kicker pills, brutalist floating badges
- All dynamically-rendered components (pain cards, product cards, assist loop, benchmarks, FAQ, demo audio) fully restyled
- Audio visualizer updated to yellow/blue brutalist palette

## Test plan

- [ ] Verify hero section renders correctly with black background and yellow accents
- [ ] Check all section backgrounds alternate correctly (cream / black / white / yellow)
- [ ] Confirm buttons show correct offset shadow on hover and press-down on active
- [ ] Verify dynamically-rendered cards (products, benchmarks, FAQ) pick up brutalist styles
- [ ] Test FAQ accordion works (details/summary toggle)
- [ ] Check audio player and visualizer render with new palette
- [ ] Test responsive layout at 900px and 600px breakpoints

Closes #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)