### PR TITLE
feat: add footer links to zapcom.ai (TES-7)

### DIFF
--- a/index.html
+++ b/index.html
@@ -488,6 +488,10 @@
       <div class="container footer-inner">
         <p>VOCA AI | AI-native conversational intelligence for revenue voice operations.</p>
         <p>&copy; <span id="year"></span> VOCA AI. All rights reserved.</p>
+        <nav class="footer-links" aria-label="Footer links">
+          <a href="https://zapcom.ai" class="footer-link" target="_blank" rel="noopener noreferrer">Privacy Policy</a>
+          <a href="https://zapcom.ai" class="footer-link" target="_blank" rel="noopener noreferrer">Terms of Service</a>
+        </nav>
       </div>
     </footer>
 

--- a/styles.css
+++ b/styles.css
@@ -1935,6 +1935,24 @@ p { margin: 0 0 1rem; }
   opacity: 0.5;
 }
 
+.footer-links {
+  display: flex;
+  gap: 1.25rem;
+}
+
+.footer-link {
+  font-size: 0.72rem;
+  font-weight: 500;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: #60a5fa;
+  text-decoration: none;
+}
+
+.footer-link:hover {
+  text-decoration: underline;
+}
+
 /* ── TOAST ─────────────────────────────────────────────────── */
 .toast {
   position: fixed;


### PR DESCRIPTION
## Summary
- Adds two links to the site footer: **Privacy Policy** and **Terms of Service**, both pointing to https://zapcom.ai
- Links are styled as uppercase blue text (`#60a5fa`) matching the footer's typographic scale
- Links open in a new tab with `rel="noopener noreferrer"` for security

## Combyne Issue
TES-7

## Test Plan
- [ ] Footer renders with both links visible
- [ ] Both links navigate to https://zapcom.ai in a new tab
- [ ] Link color is blue and underlines on hover
- [ ] Layout doesn't break on mobile (flex-wrap is inherited from `.footer-inner`)