### PR TITLE
feat: add Privacy Policy and Terms of Service links to footer (TES-8)

### DIFF
--- a/index.html
+++ b/index.html
@@ -488,6 +488,10 @@
       <div class="container footer-inner">
         <p>VOCA AI | AI-native conversational intelligence for revenue voice operations.</p>
         <p>&copy; <span id="year"></span> VOCA AI. All rights reserved.</p>
+        <nav class="footer-links" aria-label="Footer links">
+          <a href="https://zapcom.ai" class="footer-link" target="_blank" rel="noopener noreferrer">PRIVACY POLICY</a>
+          <a href="https://zapcom.ai" class="footer-link" target="_blank" rel="noopener noreferrer">TERMS OF SERVICE</a>
+        </nav>
       </div>
     </footer>
 


### PR DESCRIPTION
## Summary
- Added Privacy Policy and Terms of Service links to the site footer
- Both links point to https://zapcom.ai (per user specification)
- Labels use UPPERCASE in HTML source per user specification
- Links open in a new tab with `rel="noopener noreferrer"`

## Combyne Issue
TES-8

## Test Plan
- [ ] Footer renders both links: PRIVACY POLICY and TERMS OF SERVICE
- [ ] Both links open https://zapcom.ai in a new tab
- [ ] No regressions to existing footer layout or other sections